### PR TITLE
doc task now shows up with rake -T

### DIFF
--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '15.0.2'
+  VERSION = '15.0.3'
 end

--- a/lib/tasks/doc.rake
+++ b/lib/tasks/doc.rake
@@ -1,4 +1,5 @@
 namespace :doc do
+  desc 'Generate RDoc documentation'
   task :generate do
     #Remove directory if exists (Sooooo much faster rdoc time.)
     system('rm -rf doc/') if File.exists?('doc/index.html')


### PR DESCRIPTION
Super tiny PR - previously the `doc:generate` task would not show up with `rake -T`. Now it does - apparently all it needs is a description. This was discovered via https://github.com/cbdr/ruby-cb-api-internal/pull/110.