### PR TITLE
making the changes to match the resume API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Version History
 ----
 
 * 16.0.0 Modifying the Resume model to reflect the changes made in the API (Removal of job title from salary and
-    * addition of id to work experience and work Experience Id to salary
+        addition of id to work experience and work Experience Id to salary
 * 15.1.0 Added resume post
 * 15.0.3 Add desc to doc.rake so it shows in `rake -T`
 * 15.0.2 Include the rake tasks in the gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
+* 16.0.0 Modifying the Resume model to reflect the changes made in the API (Removal of job title from salary and
+    * addition of id to work experience and work Experience Id to salary
 * 15.1.0 Added resume post
 * 15.0.3 Add desc to doc.rake so it shows in `rake -T`
 * 15.0.2 Include the rake tasks in the gem

--- a/lib/cb/models/implementations/resumes/salary_information.rb
+++ b/lib/cb/models/implementations/resumes/salary_information.rb
@@ -3,15 +3,15 @@ module Cb
     module Resumes
       class SalaryInformation < ApiResponseModel
         attr_accessor :most_recent_pay_amount, :per_hour_or_per_year, :currency_code,
-                      :job_title, :annual_bonus, :annual_commission
+                      :annual_bonus, :annual_commission, :work_experience_id
 
         def set_model_properties
           @most_recent_pay_amount = api_response['mostRecentPayAmount']
           @per_hour_or_per_year = api_response['PerHourOrPerYear']
           @currency_code = api_response['CurrencyCode']
-          @job_title = api_response['jobTitle']
           @annual_bonus = api_response['annualBonus']
           @annual_commission = api_response['annualCommission']
+          @work_experience_id = api_response['workExperienceId']
         end
 
         def required_fields

--- a/lib/cb/models/implementations/resumes/salary_information.rb
+++ b/lib/cb/models/implementations/resumes/salary_information.rb
@@ -6,17 +6,24 @@ module Cb
                       :annual_bonus, :annual_commission, :work_experience_id
 
         def set_model_properties
-          @most_recent_pay_amount = api_response['mostRecentPayAmount']
-          @per_hour_or_per_year = api_response['PerHourOrPerYear']
-          @currency_code = api_response['CurrencyCode']
-          @annual_bonus = api_response['annualBonus']
-          @annual_commission = api_response['annualCommission']
-          @work_experience_id = api_response['workExperienceId']
+          @most_recent_pay_amount = get_api_response 'mostRecentPayAmount'
+          @per_hour_or_per_year = get_api_response 'PerHourOrPerYear'
+          @currency_code = get_api_response 'CurrencyCode'
+          @annual_bonus = get_api_response 'annualBonus'
+          @annual_commission = get_api_response 'annualCommission'
+          @work_experience_id = get_api_response 'workExperienceId'
         end
 
         def required_fields
           ['PerHourOrPerYear', 'mostRecentPayAmount']
         end
+
+        private
+
+        def get_api_response(api_key)
+          api_response['api_key']
+        end
+
       end
     end
   end

--- a/lib/cb/models/implementations/resumes/salary_information.rb
+++ b/lib/cb/models/implementations/resumes/salary_information.rb
@@ -21,7 +21,7 @@ module Cb
         private
 
         def get_api_response(api_key)
-          api_response['api_key']
+          api_response[api_key]
         end
 
       end

--- a/lib/cb/models/implementations/resumes/work_experience.rb
+++ b/lib/cb/models/implementations/resumes/work_experience.rb
@@ -3,7 +3,7 @@ module Cb
     module Resumes
       class WorkExperience < ApiResponseModel
         attr_accessor :job_title, :company_name, :employment_type, :start_date, :end_date,
-                      :currently_employed_here
+                      :currently_employed_here, :id
 
         def set_model_properties
           @job_title = api_response['jobTitle']
@@ -12,6 +12,7 @@ module Cb
           @start_date = api_response['startDate']
           @end_date = api_response['endDate']
           @currently_employed_here = api_response['currentlyEmployedHere']
+          @id = api_response['id']
         end
 
         def required_fields

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '15.1.0'
+  VERSION = '16.0.0'
 end

--- a/spec/cb/models/implementations/resume/resume_spec.rb
+++ b/spec/cb/models/implementations/resume/resume_spec.rb
@@ -43,11 +43,11 @@ module Cb
 
       context 'When APIResponse has salary information' do
         let(:resume_hash) do
-          { 'salaryInformation' => { 'jobTitle' => 'jerbs', 'PerHourOrPerYear' => 'PerHour',
+          { 'salaryInformation' => { 'workExperienceId' => 'test1', 'PerHourOrPerYear' => 'PerHour',
             'mostRecentPayAmount' => 100.00 },'userIdentifier' => 'user' }
         end
 
-        it { expect(resume.salary_information.job_title).to_not be_nil }
+        it { expect(resume.salary_information.work_experience_id).to_not be_nil }
         it { expect(resume.salary_information.most_recent_pay_amount).to_not be_nil }
       end
 
@@ -55,7 +55,7 @@ module Cb
 
         context 'and it is specifically the PerHourOrPerYear missing' do
           let(:resume_hash) do
-            { 'salaryInformation' => { 'jobTitle' => 'jerbs',
+            { 'salaryInformation' => { 'workExperienceId' => 'test1',
               'mostRecentPayAmount' => 100.00 },'userIdentifier' => 'user' }
           end
 
@@ -64,7 +64,7 @@ module Cb
 
         context 'and it is specifically the mostRecentPayAmount missing' do
           let(:resume_hash) do
-            { 'salaryInformation' => { 'jobTitle' => 'jerbs', 'PerHourOrPerYear' => 'PerHour' },
+            { 'salaryInformation' => { 'workExperienceId' => 'test1', 'PerHourOrPerYear' => 'PerHour' },
               'userIdentifier' => 'user' }
           end
 

--- a/spec/cb/models/implementations/resume/resume_spec.rb
+++ b/spec/cb/models/implementations/resume/resume_spec.rb
@@ -15,18 +15,17 @@ module Cb
       context 'When APIResponse has work experience' do
         let(:resume_hash) do
           { 'workExperience' => [{ 'jobTitle' => 'jerbs', 'currentlyEmployedHere' => 'false' }],
-          'userIdentifier' => 'user' }
+            'userIdentifier' => 'user' }
         end
 
         it { expect(resume.work_experience[0]).to_not be_nil }
       end
 
       context 'when APIResponse has invalid work experience' do
-
         context 'and specifically its the jobTitle missing' do
           let(:resume_hash) do
             { 'workExperience' => [{ 'currentlyEmployedHere' => 'false' }],
-             'userIdentifier' => 'user' }
+              'userIdentifier' => 'user' }
           end
 
           it { expect(error).to eq('jobTitle') }
@@ -34,7 +33,7 @@ module Cb
 
         context 'and specifically its the currentlyEmployedHere missing' do
           let(:resume_hash) do
-            { 'workExperience' => [{ 'jobTitle' => 'jerbs' }],'userIdentifier' => 'user' }
+            { 'workExperience' => [{ 'jobTitle' => 'jerbs' }], 'userIdentifier' => 'user' }
           end
 
           it { expect(error).to eq('currentlyEmployedHere') }
@@ -44,7 +43,7 @@ module Cb
       context 'When APIResponse has salary information' do
         let(:resume_hash) do
           { 'salaryInformation' => { 'workExperienceId' => 'test1', 'PerHourOrPerYear' => 'PerHour',
-            'mostRecentPayAmount' => 100.00 },'userIdentifier' => 'user' }
+                                     'mostRecentPayAmount' => 100.00 }, 'userIdentifier' => 'user' }
         end
 
         it { expect(resume.salary_information.work_experience_id).to_not be_nil }
@@ -52,11 +51,10 @@ module Cb
       end
 
       context 'When APIResponse hash invalid salary information' do
-
         context 'and it is specifically the PerHourOrPerYear missing' do
           let(:resume_hash) do
             { 'salaryInformation' => { 'workExperienceId' => 'test1',
-              'mostRecentPayAmount' => 100.00 },'userIdentifier' => 'user' }
+                                       'mostRecentPayAmount' => 100.00 }, 'userIdentifier' => 'user' }
           end
 
           it { expect(error).to eq('PerHourOrPerYear') }
@@ -75,7 +73,7 @@ module Cb
       context 'When APIResponse has education' do
         let(:resume_hash) do
           { 'educations' => [{ 'schoolName' => 'skool', 'majorOrProgram' => 'major' }],
-           'userIdentifier' => 'user' }
+            'userIdentifier' => 'user' }
         end
 
         it { expect(resume.educations[0].school_name).to_not be_nil }
@@ -83,11 +81,10 @@ module Cb
       end
 
       context 'When APIResponse hash invalid education' do
-
         context 'and it is specifically the schoolName missing' do
           let(:resume_hash) do
             { 'educations' => [{ 'majorOrProgram' => 'major' }],
-             'userIdentifier' => 'user' }
+              'userIdentifier' => 'user' }
           end
 
           it { expect(error).to eq('schoolName') }
@@ -96,7 +93,7 @@ module Cb
         context 'and it is specifically the majorOrProgram missing' do
           let(:resume_hash) do
             { 'educations' => [{ 'schoolName' => 'skool' }],
-             'userIdentifier' => 'user' }
+              'userIdentifier' => 'user' }
           end
 
           it { expect(error).to eq('majorOrProgram') }
@@ -106,13 +103,13 @@ module Cb
       context 'When APIResponse has skills and qualifications' do
         let(:resume_hash) do
           { 'skillsAndQualifications' => { 'accreditationsAndCertifications' => 'skillz' },
-           'userIdentifier' => 'user' }
+            'userIdentifier' => 'user' }
         end
 
         it { expect(resume.skills_and_qualifications.accreditations_and_certifications).to_not be_nil }
         context 'and when it has a language in its skills' do
           before do
-            resume_hash['skillsAndQualifications'].merge!({ 'languagesSpoken' => ['english'] })
+            resume_hash['skillsAndQualifications'].merge!('languagesSpoken' => ['english'])
           end
 
           it { expect(resume.skills_and_qualifications.languages_spoken[0]).to_not be_nil }
@@ -122,7 +119,7 @@ module Cb
       context 'When APIResponse has Relocation' do
         let(:resume_hash) do
           { 'relocations' => [{ 'city' => 'city', 'adminArea' => 'st', 'countryCode' => 'co' }],
-           'userIdentifier' => 'user' }
+            'userIdentifier' => 'user' }
         end
 
         it { expect(resume.relocations[0].city).to_not be_nil }
@@ -131,11 +128,10 @@ module Cb
       end
 
       context 'When APIResponse hash invalid Relocation' do
-
         context 'and it is specifically the city missing' do
           let(:resume_hash) do
             { 'relocations' => [{ 'adminArea' => 'st', 'countryCode' => 'co' }],
-             'userIdentifier' => 'user' }
+              'userIdentifier' => 'user' }
           end
 
           it { expect(error).to eq('city') }
@@ -143,8 +139,8 @@ module Cb
 
         context 'and it is specifically the adminArea missing' do
           let(:resume_hash) do
-            { 'relocations' => [{ 'city' => 'city','countryCode' => 'co' }],
-             'userIdentifier' => 'user' }
+            { 'relocations' => [{ 'city' => 'city', 'countryCode' => 'co' }],
+              'userIdentifier' => 'user' }
           end
 
           it { expect(error).to eq('adminArea') }
@@ -153,7 +149,7 @@ module Cb
         context 'and it is specifically the countryCode missing' do
           let(:resume_hash) do
             { 'relocations' => [{ 'city' => 'city', 'adminArea' => 'st' }],
-             'userIdentifier' => 'user' }
+              'userIdentifier' => 'user' }
           end
 
           it { expect(error).to eq('countryCode') }
@@ -163,7 +159,7 @@ module Cb
       context 'When APIResponse has government and military' do
         let(:resume_hash) do
           { 'governmentAndMilitary' => { 'hasSecurityClearance' => true, 'militaryExperience' => 'army' },
-           'userIdentifier' => 'user' }
+            'userIdentifier' => 'user' }
         end
 
         it { expect(resume.government_and_military.has_security_clearance).to be_truthy }
@@ -171,20 +167,19 @@ module Cb
       end
 
       context 'When APIResponse hash invalid Relocation' do
-
         context 'and it is specifically the hasSecurityClearance missing' do
           let(:resume_hash) do
             { 'governmentAndMilitary' => { 'militaryExperience' => 'army' },
-             'userIdentifier' => 'user' }
+              'userIdentifier' => 'user' }
           end
 
-          it {expect(error).to eq('hasSecurityClearance')}
+          it { expect(error).to eq('hasSecurityClearance') }
         end
 
         context 'and it is specifically the militaryExperience missing' do
           let(:resume_hash) do
             { 'governmentAndMilitary' => { 'hasSecurityClearance' => true },
-             'userIdentifier' => 'user' }
+              'userIdentifier' => 'user' }
           end
 
           it { expect(error).to eq('militaryExperience') }

--- a/spec/support/response_stubs/resume_get.json
+++ b/spec/support/response_stubs/resume_get.json
@@ -14,7 +14,8 @@
                     "employmentType": "ETNS",
                     "startDate": "2009-09-01T00:00:00",
                     "endDate": "2014-08-25T00:00:00",
-                    "currentlyEmployedHere": true
+                    "currentlyEmployedHere": true,
+                    "id": "test1"
                 },
                 {
                     "jobTitle": "Hair Stylist",
@@ -22,7 +23,8 @@
                     "employmentType": "ETNS",
                     "startDate": "2008-06-01T00:00:00",
                     "endDate": "2009-09-01T00:00:00",
-                    "currentlyEmployedHere": false
+                    "currentlyEmployedHere": false,
+                    "id": "test2"
                 },
                 {
                     "jobTitle": "Assistant/Receptionist",
@@ -30,7 +32,8 @@
                     "employmentType": "ETNS",
                     "startDate": "2006-09-01T00:00:00",
                     "endDate": "2008-06-01T00:00:00",
-                    "currentlyEmployedHere": false
+                    "currentlyEmployedHere": false,
+                    "id": "test3"
                 },
                 {
                     "jobTitle": "Lead role",
@@ -38,7 +41,8 @@
                     "employmentType": "ETNS",
                     "startDate": "2007-03-01T00:00:00",
                     "endDate": "2007-05-31T00:00:00",
-                    "currentlyEmployedHere": false
+                    "currentlyEmployedHere": false,
+                    "id": "test4"
                 },
                 {
                     "jobTitle": "",
@@ -46,7 +50,8 @@
                     "employmentType": "ETNS",
                     "startDate": "2006-03-01T00:00:00",
                     "endDate": "2006-05-31T00:00:00",
-                    "currentlyEmployedHere": false
+                    "currentlyEmployedHere": false,
+                    "id": "test5"
                 }
             ],
             "salaryInformation": {
@@ -55,7 +60,7 @@
                 "CurrencyCode": "",
                 "annualBonus": 0,
                 "annualCommission": 0,
-                "jobTitle": ""
+                "workExperienceId": "test1"
             },
             "educations": [
                 {


### PR DESCRIPTION
To Test:
copy and paste the following (after changing out the dev_key/ resume_hash/ user_id for your own)

--------------------------------------------------
bundle exec pry

Cb.configure do |config|
  config.dev_key    = 'dev_key'
  config.time_out  = 30
  config.debug_api  = true
end

request = Cb::Requests::Resumes::Get.new( {resume_hash: 'resume_hash', external_user_id: 'user_id'})

client = Cb::Client.new

response = client.execute request

----------------------------------------------------
you should see that the work experiences now have a node "id", and that Salary information does not have job title any more, but does have "workExperienceId"