### PR TITLE
Added support for handling 401 unauthorized errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
-
+* 16.1.0 Added support for handling a 401 unauthorized response. We should now raise specific UnauthorizedErrors.
 * 16.0.0 Modifying the Resume model to reflect the changes made in the API (Removal of job title from salary and
         addition of id to work experience and work Experience Id to salary
 * 15.1.0 Added resume post

--- a/lib/cb/exceptions.rb
+++ b/lib/cb/exceptions.rb
@@ -3,4 +3,5 @@ module Cb
   class ExpectedResponseFieldMissing      < StandardError; end
   class ApiResponseError                  < StandardError; end
   class ServiceUnavailableError           < ApiResponseError; end
+  class UnauthorizedError                 < ApiResponseError; end
 end

--- a/lib/cb/utils/validator.rb
+++ b/lib/cb/utils/validator.rb
@@ -15,6 +15,7 @@ module Cb
       def raise_response_code_errors(response)
         code = response.code rescue nil
         raise Cb::ServiceUnavailableError if code == 503
+        raise Cb::UnauthorizedError if code == 401
       end
 
       def process_response_body(response)

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '16.0.0'
+  VERSION = '16.1.0'
 end

--- a/spec/cb/utils/validator_spec.rb
+++ b/spec/cb/utils/validator_spec.rb
@@ -53,6 +53,11 @@ module Cb
       expect{ ResponseValidator.validate(response) }.to raise_error(Cb::ServiceUnavailableError)
     end
 
+    it 'should raise an UnauthorizedError when status code is 401' do
+      response.stub(:code).and_return(401)
+      expect{ ResponseValidator.validate(response) }.to raise_error(Cb::UnauthorizedError)
+    end
+
     context 'when there are JSON parsing errors' do
       context 'and the content payload is not XML' do
         it 'returns an empty hash' do


### PR DESCRIPTION
401 responses will now throw out an UnauthorizedError. This will allow handling and recovering this specific response down the line.