### PR TITLE
Api changes for work experience id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+* 16.2.0 Added support for work experience ID in resume put
 * 16.1.0 Added support for handling a 401 unauthorized response. We should now raise specific UnauthorizedErrors.
 * 16.0.0 Modifying the Resume model to reflect the changes made in the API (Removal of job title from salary and
         addition of id to work experience and work Experience Id to salary

--- a/lib/cb/requests/resumes/put.rb
+++ b/lib/cb/requests/resumes/put.rb
@@ -46,7 +46,8 @@ module Cb
               employmentType: experience[:employment_type],
               startDate: experience[:start_date],
               endDate: experience[:end_date],
-              currentlyEmployedHere: experience[:currently_employed_here]
+              currentlyEmployedHere: experience[:currently_employed_here],
+              id: experience[:id]
             }
           end
         end
@@ -58,7 +59,7 @@ module Cb
             mostRecentPayAmount: salary[:most_recent_pay_amount],
             perHourOrPerYear: salary[:per_hour_or_per_year],
             currencyCode: salary[:currency_code],
-            jobTitle: salary[:job_title],
+            workExperienceId: salary[:work_experience_id],
             annualBonus: salary[:annual_bonus],
             annualCommission: salary[:annual_commission],
           }

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '16.1.0'
+  VERSION = '16.2.0'
 end

--- a/spec/support/mocks/resume.rb
+++ b/spec/support/mocks/resume.rb
@@ -16,7 +16,8 @@ module Mocks
                 employment_type: 'ETNS',
                 start_date: '2009-09-01T00:00:00',
                 end_date: '2014-08-28T00:00:00',
-                currently_employed_here: true
+                currently_employed_here: true,
+                id:'workexperienceID'
               },
               {
                 job_title: 'Hair Stylist',
@@ -24,7 +25,8 @@ module Mocks
                 employment_type: 'ETNS',
                 start_date: '2008-06-01T00:00:00',
                 end_date: '2009-09-01T00:00:00',
-                currently_employed_here: false
+                currently_employed_here: false,
+                id:'workexperienceID'
               },
               {
                 job_title: 'Assistant/Receptionist',
@@ -32,7 +34,8 @@ module Mocks
                 employment_type: 'ETNS',
                 start_date: '2006-09-01T00:00:00',
                 end_date: '2008-06-01T00:00:00',
-                currently_employed_here: false
+                currently_employed_here: false,
+                id:'workexperienceID'
               },
               {
                 job_title: 'Lead role',
@@ -40,7 +43,8 @@ module Mocks
                 employment_type: 'ETNS',
                 start_date: '2007-03-01T00:00:00',
                 end_date: '2007-05-31T00:00:00',
-                currently_employed_here: false
+                currently_employed_here: false,
+                id:'workexperienceID'
               },
               {
                 job_title: 'magic place',
@@ -48,7 +52,8 @@ module Mocks
                 employment_type: 'ETNS',
                 start_date: '2006-03-01T00:00:00',
                 end_date: '2006-05-31T00:00:00',
-                currently_employed_here: false
+                currently_employed_here: false,
+                id:'workexperienceID'
               }
             ],
           salary_information:
@@ -56,9 +61,9 @@ module Mocks
               most_recent_pay_amount: 0,
               per_hour_or_per_year: 'Hour',
               currency_code: 'USD',
+              work_experience_id: 'workexperienceID',
               annual_bonus: 0,
-              annual_commission: 0,
-              job_title: 'magic place'
+              annual_commission: 0
             },
           educations:
             [
@@ -117,7 +122,8 @@ module Mocks
                 'employmentType'=> 'ETNS',
                 'startDate'=> '2009-09-01T00:00:00',
                 'endDate'=> '2014-08-28T00:00:00',
-                'currentlyEmployedHere'=> true
+                'currentlyEmployedHere'=> true,
+                'id'=>'workexperienceID'
               },
               {
                 'jobTitle'=> 'Hair Stylist',
@@ -125,7 +131,8 @@ module Mocks
                 'employmentType'=> 'ETNS',
                 'startDate'=> '2008-06-01T00:00:00',
                 'endDate'=> '2009-09-01T00:00:00',
-                'currentlyEmployedHere'=> false
+                'currentlyEmployedHere'=> false,
+                'id'=>'workexperienceID'
               },
               {
                 'jobTitle'=> 'Assistant/Receptionist',
@@ -133,7 +140,8 @@ module Mocks
                 'employmentType'=> 'ETNS',
                 'startDate'=> '2006-09-01T00:00:00',
                 'endDate'=> '2008-06-01T00:00:00',
-                'currentlyEmployedHere'=> false
+                'currentlyEmployedHere'=> false,
+                'id'=>'workexperienceID'
               },
               {
                 'jobTitle'=> 'Lead role',
@@ -141,7 +149,8 @@ module Mocks
                 'employmentType'=> 'ETNS',
                 'startDate'=> '2007-03-01T00:00:00',
                 'endDate'=> '2007-05-31T00:00:00',
-                'currentlyEmployedHere'=> false
+                'currentlyEmployedHere'=> false,
+                'id'=>'workexperienceID'
               },
               {
                 'jobTitle'=> 'magic place',
@@ -149,7 +158,8 @@ module Mocks
                 'employmentType'=> 'ETNS',
                 'startDate'=> '2006-03-01T00:00:00',
                 'endDate'=> '2006-05-31T00:00:00',
-                'currentlyEmployedHere'=> false
+                'currentlyEmployedHere'=> false,
+                'id'=>'workexperienceID'
               }
             ],
           'salaryInformation'=>
@@ -157,9 +167,10 @@ module Mocks
               'mostRecentPayAmount'=> 0,
               'perHourOrPerYear'=> 'Hour',
               'currencyCode'=> 'USD',
-              'jobTitle'=> 'magic place',
+              'workExperienceId'=>'workexperienceID',
               'annualBonus'=> 0,
-              'annualCommission'=> 0,
+              'annualCommission'=> 0
+
             },
           'educations'=>
             [


### PR DESCRIPTION
Adding support for work experience ID in place of "job title" in the salary section of resume.
Also adding work experience ID as a field in the work experience section of resume.

https://careerbuilder.mingle.thoughtworks.com/projects/job_discovery_ux__search___re/cards/768