### PR TITLE
RSpec 3 - for real!

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
 --require 'rspec/pride'
---format RSpec::Pride
+--format PrideFormatter

--- a/cb-api.gemspec
+++ b/cb-api.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri', '~> 1.0'
 
   s.add_development_dependency 'rake', '>= 0.8.7'
-  s.add_development_dependency 'webmock', '~> 1.9.0'
+  s.add_development_dependency 'webmock', '~> 1.9'
   s.add_development_dependency 'simplecov', '>= 0.7.1'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rdoc', '~> 3.12.2'

--- a/cb-api.gemspec
+++ b/cb-api.gemspec
@@ -24,10 +24,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '>= 0.8.7'
   s.add_development_dependency 'webmock', '~> 1.9.0'
   s.add_development_dependency 'simplecov', '>= 0.7.1'
-  s.add_development_dependency 'rspec', '~> 2.14'
+  s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rdoc', '~> 3.12.2'
-  s.add_development_dependency 'rspec-pride', '~> 2.2.0'
+  s.add_development_dependency 'rspec-pride', '~> 3.0'
   s.add_development_dependency 'pry', '0.9.12.1'
   s.add_development_dependency 'rb-readline', '~> 0.5.0'
-
 end

--- a/spec/cb/api_spec.rb
+++ b/spec/cb/api_spec.rb
@@ -4,8 +4,8 @@ describe Cb::Utils::Api do
   context '#initialize' do
     it 'sets default gzip headers' do
       client = Cb::Utils::Api.new
-      client.class.headers.should have_key('accept-encoding')
-      client.class.headers['accept-encoding'].should == 'deflate, gzip'
+      expect(client.class.headers).to have_key('accept-encoding')
+      expect(client.class.headers['accept-encoding']).to eq('deflate, gzip')
 
     end
   end

--- a/spec/cb/cb_spec.rb
+++ b/spec/cb/cb_spec.rb
@@ -6,14 +6,14 @@ describe Cb do
     context 'when called with a block' do
       it 'yields a default configuration to play with' do
         Cb.configure do |c|
-          c.should be_an_instance_of Cb::Config
+          expect(c).to be_an_instance_of Cb::Config
         end
       end
 
       it 'caches the config if called again' do
         original_object_id = ''
         Cb.configure { |c1| original_object_id = c1.object_id }
-        Cb.configure { |c2| c2.object_id.should eq original_object_id }
+        Cb.configure { |c2| expect(c2.object_id).to eq original_object_id }
       end
     end
   end

--- a/spec/cb/client_spec.rb
+++ b/spec/cb/client_spec.rb
@@ -10,12 +10,12 @@ module Cb
     context 'initialize' do
       it 'should not use a callback block' do
         client = Cb::Client.new()
-        client.callback_block.should == nil
+        expect(client.callback_block).to eq(nil)
       end
 
       it 'should pass a correct callback' do
         client = Cb::Client.new {}
-        client.callback_block.class.should == Proc
+        expect(client.callback_block.class).to eq(Proc)
       end
     end
 
@@ -28,7 +28,7 @@ module Cb
         callback_test = nil
         client = Cb::Client.new { |callback| callback_test = callback}
         client.callback_block.call(@callback_value)
-        callback_test.should == @callback_value
+        expect(callback_test).to eq(@callback_value)
       end
     end
 
@@ -42,16 +42,16 @@ module Cb
 
       context 'post' do
         before :each do
-          mock_api.stub(:execute_http_request).and_return(Hash.new)
-          mock_api.stub(:append_api_responses)
-          Cb::Utils::Api.stub(:new).and_return(mock_api)
-          Cb::Utils::ResponseMap.stub(:response_for).and_return(Mocks::Response)
+          allow(mock_api).to receive(:execute_http_request).and_return(Hash.new)
+          allow(mock_api).to receive(:append_api_responses)
+          allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
+          allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
 
           @request = Mocks::Request.new(:post)
         end
 
         it 'should call the api using post' do
-          mock_api.should_receive(:execute_http_request).
+          expect(mock_api).to receive(:execute_http_request).
               with(:post, base_uri, 'parts unknown', {:query=>nil, :headers=>nil, :body=>nil}).
               and_return(Hash.new)
 
@@ -61,16 +61,16 @@ module Cb
 
       context 'get' do
         before :each do
-          mock_api.stub(:execute_http_request).and_return(Hash.new)
-          mock_api.stub(:append_api_responses)
-          Cb::Utils::Api.stub(:new).and_return(mock_api)
-          Cb::Utils::ResponseMap.stub(:response_for).and_return(Mocks::Response)
+          allow(mock_api).to receive(:execute_http_request).and_return(Hash.new)
+          allow(mock_api).to receive(:append_api_responses)
+          allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
+          allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
 
           @request = Mocks::Request.new(:get)
         end
 
         it 'should call the api using get' do
-          mock_api.should_receive(:execute_http_request).
+          expect(mock_api).to receive(:execute_http_request).
               with(:get, base_uri, 'parts unknown', {:query=>nil, :headers=>nil, :body=>nil}).
               and_return(Hash.new)
 
@@ -80,16 +80,16 @@ module Cb
 
       context 'put' do
         before :each do
-          mock_api.stub(:execute_http_request).and_return(Hash.new)
-          mock_api.stub(:append_api_responses)
-          Cb::Utils::Api.stub(:new).and_return(mock_api)
-          Cb::Utils::ResponseMap.stub(:response_for).and_return(Mocks::Response)
+          allow(mock_api).to receive(:execute_http_request).and_return(Hash.new)
+          allow(mock_api).to receive(:append_api_responses)
+          allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
+          allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
 
           @request = Mocks::Request.new(:put)
         end
 
         it 'should call the api using put' do
-          mock_api.should_receive(:execute_http_request).
+          expect(mock_api).to receive(:execute_http_request).
               with(:put, base_uri, 'parts unknown', {:query=>nil, :headers=>nil, :body=>nil}).
               and_return(Hash.new)
 
@@ -108,16 +108,16 @@ module Cb
 
       context 'post' do
         before :each do
-          mock_api.stub(:execute_http_request).and_return(Hash.new)
-          mock_api.stub(:append_api_responses)
-          Cb::Utils::Api.stub(:new).and_return(mock_api)
-          Cb::Utils::ResponseMap.stub(:response_for).and_return(Mocks::Response)
+          allow(mock_api).to receive(:execute_http_request).and_return(Hash.new)
+          allow(mock_api).to receive(:append_api_responses)
+          allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
+          allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
 
           @request = Mocks::Request.new(:post)
         end
 
         it 'should call the api using post' do
-          mock_api.should_receive(:execute_http_request).
+          expect(mock_api).to receive(:execute_http_request).
               with(:post, base_uri, 'parts unknown', {:query=>nil, :headers=>nil, :body=>nil}).
               and_yield("test").
               and_return(Hash.new)
@@ -128,16 +128,16 @@ module Cb
 
       context 'get' do
         before :each do
-          mock_api.stub(:execute_http_request).and_return(Hash.new)
-          mock_api.stub(:append_api_responses)
-          Cb::Utils::Api.stub(:new).and_return(mock_api)
-          Cb::Utils::ResponseMap.stub(:response_for).and_return(Mocks::Response)
+          allow(mock_api).to receive(:execute_http_request).and_return(Hash.new)
+          allow(mock_api).to receive(:append_api_responses)
+          allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
+          allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
 
           @request = Mocks::Request.new(:get)
         end
 
         it 'should call the api using get' do
-          mock_api.should_receive(:execute_http_request).
+          expect(mock_api).to receive(:execute_http_request).
               with(:get, base_uri, 'parts unknown', {:query=>nil, :headers=>nil, :body=>nil}).
               and_yield("test").
               and_return(Hash.new)
@@ -148,16 +148,16 @@ module Cb
 
       context 'put' do
         before :each do
-          mock_api.stub(:execute_http_request).and_return(Hash.new)
-          mock_api.stub(:append_api_responses)
-          Cb::Utils::Api.stub(:new).and_return(mock_api)
-          Cb::Utils::ResponseMap.stub(:response_for).and_return(Mocks::Response)
+          allow(mock_api).to receive(:execute_http_request).and_return(Hash.new)
+          allow(mock_api).to receive(:append_api_responses)
+          allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
+          allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
 
           @request = Mocks::Request.new(:put)
         end
 
         it 'should call the api using put' do
-          mock_api.should_receive(:execute_http_request).
+          expect(mock_api).to receive(:execute_http_request).
               with(:put, base_uri, 'parts unknown', {:query=>nil, :headers=>nil, :body=>nil}).
               and_yield("test").
               and_return(Hash.new)

--- a/spec/cb/clients/anon_saved_search_spec.rb
+++ b/spec/cb/clients/anon_saved_search_spec.rb
@@ -29,9 +29,9 @@ module Cb
         context 'should successfully create a new anonymous saved search via:' do
           def assert_no_error_on_model(&api_calling_code)
             saved_search_response = api_calling_code.call
-            saved_search_response.class.should eq Responses::AnonymousSavedSearch::Create
+            expect(saved_search_response.class).to eq Responses::AnonymousSavedSearch::Create
             model_class = saved_search_response.model.class
-            model_class.should eq Models::SavedSearch
+            expect(model_class).to eq Models::SavedSearch
           end
 
           before :each do
@@ -69,7 +69,7 @@ module Cb
 
         it 'should successfully delete an anonymous saved search' do
           response = Cb.anon_saved_search.new.delete @args
-          response.model.status.should eq 'Success'
+          expect(response.model.status).to eq 'Success'
         end
       end
     end # delete

--- a/spec/cb/clients/application_external_spec.rb
+++ b/spec/cb/clients/application_external_spec.rb
@@ -27,8 +27,8 @@ module Cb
         it 'the same application object is returned that is supplied for input' do
           stub_api_call_to_return(Hash.new)
           app = submit_app(external_app)
-          app.should eq external_app
-          app.object_id.should eq external_app.object_id
+          expect(app).to eq external_app
+          expect(app.object_id).to eq external_app.object_id
         end
 
         context 'if the ApplyUrl field comes back in the response' do
@@ -36,7 +36,7 @@ module Cb
 
           it 'the ApplyUrl is set on the returned app' do
             app = submit_app(external_app)
-            app.apply_url.should eq 'https://bacondreamz.net'
+            expect(app.apply_url).to eq 'https://bacondreamz.net'
           end
         end
 
@@ -45,25 +45,25 @@ module Cb
 
           it 'the ApplyUrl on the returned app is blank' do
             app = submit_app(external_app)
-            app.apply_url.empty?.should eq true
+            expect(app.apply_url.empty?).to eq true
           end
         end
 
         context 'when posting to the API' do
           before(:each) do
             @mock_api = double(Cb::Utils::Api)
-            @mock_api.stub(:cb_post)
-            @mock_api.stub(:append_api_responses)
-            Cb::Utils::Api.stub(:new).and_return @mock_api
+            allow(@mock_api).to receive(:cb_post)
+            allow(@mock_api).to receive(:append_api_responses)
+            allow(Cb::Utils::Api).to receive(:new).and_return @mock_api
           end
 
           it 'converts the application to xml' do
-            @mock_api.should_receive(:cb_post).with(kind_of(String), body: external_app.to_xml).and_return(Hash.new)
+            expect(@mock_api).to receive(:cb_post).with(kind_of(String), body: external_app.to_xml).and_return(Hash.new)
             submit_app(external_app)
           end
 
           it 'posts to the application external API endpoint' do
-            @mock_api.should_receive(:cb_post).with(Cb.configuration.uri_application_external, kind_of(Hash)).and_return(Hash.new)
+            expect(@mock_api).to receive(:cb_post).with(Cb.configuration.uri_application_external, kind_of(Hash)).and_return(Hash.new)
             submit_app(external_app)
           end
         end

--- a/spec/cb/clients/application_spec.rb
+++ b/spec/cb/clients/application_spec.rb
@@ -11,7 +11,7 @@ module Cb
 
     describe '#get' do
       before {
-        Cb::Utils::Api.any_instance.stub(:cb_get).and_return(response_stub)
+        allow_any_instance_of(Cb::Utils::Api).to receive(:cb_get).and_return(response_stub)
       }
       let(:criteria) { Criteria::Application::Get.new.application_did('app_did') }
 
@@ -23,30 +23,30 @@ module Cb
 
       it 'sends #cb_get to api_client a uri with the application_did' do
         expected_uri = "/cbapi/application/#{criteria.application_did}"
-        Cb::Utils::Api.any_instance.should_receive(:cb_get).with(expected_uri, anything)
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_get).with(expected_uri, anything)
 
         client.get(criteria)
       end
 
       it 'sends #cb_get to api_client headers with the developer_key' do
-        Cb::Utils::Api.any_instance.should_receive(:cb_get).with do |uri, hash|
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_get).with { |instance, uri, hash|
           hash[:headers]['DeveloperKey'] == 'mydevkey'
-        end
+        }
 
         client.get(criteria)
       end
 
       it 'sends #cb_get to api_client headers with the host_site' do
-        Cb::Utils::Api.any_instance.should_receive(:cb_get).with do |uri, hash|
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_get).with { |instance, uri, hash|
           hash[:headers]['HostSite'] == 'US'
-        end
+        }
 
         client.get(criteria)
       end
     end
 
     describe '#create' do
-      before { Cb::Utils::Api.any_instance.stub(:cb_post).and_return(response_stub) }
+      before { allow_any_instance_of(Cb::Utils::Api).to receive(:cb_post).and_return(response_stub) }
       let(:criteria) { Criteria::Application::Create.new.resume(resume).cover_letter(cover_letter).responses(responses).host_site(host_site) }
       let(:host_site) { nil }
       let(:resume) { Criteria::Application::Resume.new }
@@ -61,23 +61,23 @@ module Cb
 
       it 'sends #cb_post to api_client a uri with no did' do
         expected_uri = "/cbapi/application/"
-        Cb::Utils::Api.any_instance.should_receive(:cb_post).with(expected_uri, anything)
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with(expected_uri, anything)
 
         client.create(criteria)
       end
 
       it 'sends #cb_post to api_client headers with the developer_key' do
-        Cb::Utils::Api.any_instance.should_receive(:cb_post).with do |uri, hash|
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with { |instance, uri, hash|
           hash[:headers]['DeveloperKey'] == 'mydevkey'
-        end
+        }
 
         client.create(criteria)
       end
 
       it 'sends #cb_post to api_client headers with the host_site' do
-        Cb::Utils::Api.any_instance.should_receive(:cb_post).with do |uri, hash|
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with { |instance, uri, hash|
           hash[:headers]['HostSite'] == 'US'
-        end
+        }
 
         client.create(criteria)
       end
@@ -86,9 +86,9 @@ module Cb
         let(:host_site) { 'GR' }
         
         it 'sends #cb_post to api_client headers with the host_site from criteria' do
-          Cb::Utils::Api.any_instance.should_receive(:cb_post).with do |uri, hash|
+          expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with { |instance, uri, hash|
             hash[:headers]['HostSite'] == 'GR'
-          end
+          }
 
           client.create(criteria)
         end
@@ -97,7 +97,7 @@ module Cb
 
     describe '#update' do
       before {
-        Cb::Utils::Api.any_instance.stub(:cb_put).and_return(response_stub)
+        allow_any_instance_of(Cb::Utils::Api).to receive(:cb_put).and_return(response_stub)
       }
       let(:criteria) {
         Criteria::Application::Update.new.resume(resume).cover_letter(cover_letter).responses(responses)
@@ -115,23 +115,23 @@ module Cb
 
       it 'sends #cb_put to api_client a uri with the application_did' do
         expected_uri = "/cbapi/application/#{criteria.application_did}"
-        Cb::Utils::Api.any_instance.should_receive(:cb_put).with(expected_uri, anything)
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_put).with(expected_uri, anything)
 
         client.update(criteria)
       end
 
       it 'sends #cb_put to api_client headers with the developer_key' do
-        Cb::Utils::Api.any_instance.should_receive(:cb_put).with do |uri, hash|
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_put).with { |instance, uri, hash|
           hash[:headers]['DeveloperKey'] == 'mydevkey'
-        end
+        }
 
         client.update(criteria)
       end
 
       it 'sends #cb_put to api_client headers with the host_site' do
-        Cb::Utils::Api.any_instance.should_receive(:cb_put).with do |uri, hash|
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_put).with { |instance, uri, hash|
           hash[:headers]['HostSite'] == 'US'
-        end
+        }
 
         client.update(criteria)
       end
@@ -141,11 +141,11 @@ module Cb
     describe '#form' do
       let(:did) { 'hotdog sandwich' }
       let(:response_stub) { JSON.parse File.read('spec/support/response_stubs/application_form.json') }
-      before { Cb::Utils::Api.any_instance.stub(:cb_get).and_return(response_stub) }
+      before { allow_any_instance_of(Cb::Utils::Api).to receive(:cb_get).and_return(response_stub) }
 
       it 'GETs the correct url with supplied job did substituted in' do
         expected_uri = Cb.configuration.uri_application_form.sub(':did', did)
-        Cb.api_client.any_instance.should_receive(:cb_get).with(expected_uri, anything)
+        expect_any_instance_of(Cb.api_client).to receive(:cb_get).with(expected_uri, anything)
         client.form(did)
       end
 
@@ -155,10 +155,10 @@ module Cb
       end
 
       it 'sends hostsite and developer key in the headers' do
-        Cb::Utils::Api.any_instance.should_receive(:cb_get).with do |uri, hash|
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_get).with { |instance, uri, hash|
           hash[:headers]['HostSite'] == 'US'
           hash[:headers]['DeveloperKey'] == 'mydevkey'
-        end
+        }
 
         client.form(did)
       end

--- a/spec/cb/clients/application_spec.rb
+++ b/spec/cb/clients/application_spec.rb
@@ -2,151 +2,116 @@ require 'spec_helper'
 
 module Cb
   describe Clients::Application do
-    before {
+    shared_examples 'it passes the correct headers' do
+      let(:options) do
+        {
+          :headers => {
+            'DeveloperKey' => Cb.configuration.dev_key,
+            'HostSite' => Cb.configuration.host_site,
+            'Content-Type' => 'application/json'
+          }
+        }
+      end
+
+      it 'passes the correct headers in the options hash' do
+        expect_any_instance_of(Cb::Utils::Api).to receive(http_calling_method).with(anything, options)
+        subject
+      end
+    end
+
+    before do
       Cb.configuration.dev_key = 'mydevkey'
       Cb.configuration.host_site = 'US'
-    }
+    end
+
     let(:client) { Clients::Application }
     let(:response_stub) { YAML.load open('spec/support/response_stubs/application.yml') }
 
     describe '#get' do
-      before {
+      subject { client.get(criteria) }
+
+      before do
         allow_any_instance_of(Cb::Utils::Api).to receive(:cb_get).and_return(response_stub)
-      }
+      end
+
       let(:criteria) { Criteria::Application::Get.new.application_did('app_did') }
+      let(:http_calling_method) { :cb_get }
 
       it 'returns an application response' do
-        expect(
-          client.get(criteria)
-        ).to be_a Responses::Application
+        expect(subject).to be_a Responses::Application
       end
 
       it 'sends #cb_get to api_client a uri with the application_did' do
         expected_uri = "/cbapi/application/#{criteria.application_did}"
-        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_get).with(expected_uri, anything)
-
-        client.get(criteria)
+        expect_any_instance_of(Cb::Utils::Api).to receive(http_calling_method).with(expected_uri, anything)
+        subject
       end
 
-      it 'sends #cb_get to api_client headers with the developer_key' do
-        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_get).with { |instance, uri, hash|
-          hash[:headers]['DeveloperKey'] == 'mydevkey'
-        }
-
-        client.get(criteria)
-      end
-
-      it 'sends #cb_get to api_client headers with the host_site' do
-        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_get).with { |instance, uri, hash|
-          hash[:headers]['HostSite'] == 'US'
-        }
-
-        client.get(criteria)
-      end
+      it_behaves_like 'it passes the correct headers'
     end
 
     describe '#create' do
+      subject { client.create(criteria) }
+
       before { allow_any_instance_of(Cb::Utils::Api).to receive(:cb_post).and_return(response_stub) }
       let(:criteria) { Criteria::Application::Create.new.resume(resume).cover_letter(cover_letter).responses(responses).host_site(host_site) }
       let(:host_site) { nil }
       let(:resume) { Criteria::Application::Resume.new }
       let(:cover_letter) { Criteria::Application::CoverLetter.new }
       let(:responses) { [Criteria::Application::Response.new] }
+      let(:http_calling_method) { :cb_post }
 
       it 'returns an application response' do
-        expect(
-          client.create(criteria)
-        ).to be_a Responses::Application
+        expect(client.create(criteria)).to be_a Responses::Application
       end
 
       it 'sends #cb_post to api_client a uri with no did' do
         expected_uri = "/cbapi/application/"
-        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with(expected_uri, anything)
-
-        client.create(criteria)
+        expect_any_instance_of(Cb::Utils::Api).to receive(http_calling_method).with(expected_uri, anything)
+        subject
       end
 
-      it 'sends #cb_post to api_client headers with the developer_key' do
-        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with { |instance, uri, hash|
-          hash[:headers]['DeveloperKey'] == 'mydevkey'
-        }
-
-        client.create(criteria)
-      end
-
-      it 'sends #cb_post to api_client headers with the host_site' do
-        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with { |instance, uri, hash|
-          hash[:headers]['HostSite'] == 'US'
-        }
-
-        client.create(criteria)
-      end
-
-      context 'when we receive a host site in our criteria' do
-        let(:host_site) { 'GR' }
-        
-        it 'sends #cb_post to api_client headers with the host_site from criteria' do
-          expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with { |instance, uri, hash|
-            hash[:headers]['HostSite'] == 'GR'
-          }
-
-          client.create(criteria)
-        end
-      end
+      it_behaves_like 'it passes the correct headers'
     end
 
     describe '#update' do
-      before {
-        allow_any_instance_of(Cb::Utils::Api).to receive(:cb_put).and_return(response_stub)
-      }
-      let(:criteria) {
-        Criteria::Application::Update.new.resume(resume).cover_letter(cover_letter).responses(responses)
-          .application_did('app_did').job_did('job_did')
-      }
+      subject { client.update(criteria) }
+
+      before { allow_any_instance_of(Cb::Utils::Api).to receive(:cb_put).and_return(response_stub) }
       let(:resume) { Criteria::Application::Resume.new }
       let(:cover_letter) { Criteria::Application::CoverLetter.new }
       let(:responses) { [Criteria::Application::Response.new] }
+      let(:http_calling_method) { :cb_put }
+      let(:criteria) do
+        Criteria::Application::Update.new.resume(resume).cover_letter(cover_letter).responses(responses)
+          .application_did('app_did').job_did('job_did')
+      end
 
       it 'returns an application response' do
-        expect(
-          client.update(criteria)
-        ).to be_a Responses::Application
+        expect(subject).to be_a Responses::Application
       end
 
       it 'sends #cb_put to api_client a uri with the application_did' do
         expected_uri = "/cbapi/application/#{criteria.application_did}"
         expect_any_instance_of(Cb::Utils::Api).to receive(:cb_put).with(expected_uri, anything)
-
-        client.update(criteria)
+        subject
       end
 
-      it 'sends #cb_put to api_client headers with the developer_key' do
-        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_put).with { |instance, uri, hash|
-          hash[:headers]['DeveloperKey'] == 'mydevkey'
-        }
-
-        client.update(criteria)
-      end
-
-      it 'sends #cb_put to api_client headers with the host_site' do
-        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_put).with { |instance, uri, hash|
-          hash[:headers]['HostSite'] == 'US'
-        }
-
-        client.update(criteria)
-      end
-
+      it_behaves_like 'it passes the correct headers'
     end
 
     describe '#form' do
+      subject { client.form(did) }
+
       let(:did) { 'hotdog sandwich' }
+      let(:http_calling_method) { :cb_get }
       let(:response_stub) { JSON.parse File.read('spec/support/response_stubs/application_form.json') }
-      before { allow_any_instance_of(Cb::Utils::Api).to receive(:cb_get).and_return(response_stub) }
+      before { allow_any_instance_of(Cb::Utils::Api).to receive(http_calling_method).and_return(response_stub) }
 
       it 'GETs the correct url with supplied job did substituted in' do
         expected_uri = Cb.configuration.uri_application_form.sub(':did', did)
-        expect_any_instance_of(Cb.api_client).to receive(:cb_get).with(expected_uri, anything)
-        client.form(did)
+        expect_any_instance_of(Cb.api_client).to receive(http_calling_method).with(expected_uri, anything)
+        subject
       end
 
       it 'returns an instance of the application form response class' do
@@ -154,14 +119,7 @@ module Cb
         expect(response).to be_an_instance_of Cb::Responses::ApplicationForm
       end
 
-      it 'sends hostsite and developer key in the headers' do
-        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_get).with { |instance, uri, hash|
-          hash[:headers]['HostSite'] == 'US'
-          hash[:headers]['DeveloperKey'] == 'mydevkey'
-        }
-
-        client.form(did)
-      end
+      it_behaves_like 'it passes the correct headers'
     end
   end
 end

--- a/spec/cb/clients/category_spec.rb
+++ b/spec/cb/clients/category_spec.rb
@@ -22,7 +22,7 @@ module Cb
     context '.new' do
       it 'should create a new category api project' do
         category_api = Cb::Clients::Category.new
-        category_api.is_a?(Cb::Clients::Category).should == true
+        expect(category_api.is_a?(Cb::Clients::Category)).to eq(true)
       end
     end
 

--- a/spec/cb/clients/company_spec.rb
+++ b/spec/cb/clients/company_spec.rb
@@ -13,9 +13,9 @@ module Cb
         query_hash = { query: { CompanyDID: target_did, hostsite: Cb.configuration.host_site }}
 
         cb_api_client = double(Cb::Utils::Api)
-        cb_api_client.should_receive(:cb_get).with(Cb.configuration.uri_company_find, query_hash).and_return(Hash.new)
-        cb_api_client.stub(:append_api_responses)
-        Cb::Utils::Api.stub(:new).and_return(cb_api_client)
+        expect(cb_api_client).to receive(:cb_get).with(Cb.configuration.uri_company_find, query_hash).and_return(Hash.new)
+        allow(cb_api_client).to receive(:append_api_responses)
+        allow(Cb::Utils::Api).to receive(:new).and_return(cb_api_client)
 
         Cb::Clients::Company.find_by_did(target_did)
       end
@@ -56,7 +56,7 @@ module Cb
       context 'when a string is the input arg' do
         context 'and the input string is empty' do
           it 'does not end up performing the company lookup' do
-            Cb::Clients::Company.should_not_receive(:find_by_did)
+            expect(Cb::Clients::Company).not_to receive(:find_by_did)
             Cb::Clients::Company.find_for(String.new)
           end
         end
@@ -64,7 +64,7 @@ module Cb
         context 'and the input string is not empty' do
           it 'calls #find_by_did with the supplied DID' do
             target_did = 'fake-did'
-            Cb::Clients::Company.should_receive(:find_by_did).with(target_did)
+            expect(Cb::Clients::Company).to receive(:find_by_did).with(target_did)
             Cb::Clients::Company.find_for(target_did)
           end
         end
@@ -73,7 +73,7 @@ module Cb
       context 'when a Cb::CbJob is the input arg' do
         it "calls #find_by_did with the job model's company_did" do
           job_model = Cb::Models::Job.new('CompanyDID' => 'fake-did')
-          Cb::Clients::Company.should_receive(:find_by_did).with(job_model.company_did)
+          expect(Cb::Clients::Company).to receive(:find_by_did).with(job_model.company_did)
           Cb::Clients::Company.find_for(job_model)
         end
       end

--- a/spec/cb/clients/education_spec.rb
+++ b/spec/cb/clients/education_spec.rb
@@ -13,13 +13,13 @@ module Cb
         let(:mock_api) { double(Cb::Utils::Api) }
 
         before :each do
-          mock_api.stub(:append_api_responses)
-          mock_api.stub(:cb_get).and_return(Hash.new)
-          Cb::Utils::Api.stub(:new).and_return(mock_api)
+          allow(mock_api).to receive(:append_api_responses)
+          allow(mock_api).to receive(:cb_get).and_return(Hash.new)
+          allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
         end
 
         it 'calls #append_api_responses on the Cb API utility client' do
-          mock_api.should_receive(:append_api_responses)
+          expect(mock_api).to receive(:append_api_responses)
           Cb::Clients::Education.get_for('US')
         end
 
@@ -28,7 +28,7 @@ module Cb
           api_uri      = Cb.configuration.uri_education_code
           query_hash   = { :query => { :countrycode => country_code}}
 
-          mock_api.should_receive(:cb_get).with(api_uri, query_hash)
+          expect(mock_api).to receive(:cb_get).with(api_uri, query_hash)
           Cb::Clients::Education.get_for(country_code)
         end
       end

--- a/spec/cb/clients/employee_types_spec.rb
+++ b/spec/cb/clients/employee_types_spec.rb
@@ -6,28 +6,28 @@ module Cb
     let(:cb_api_client)     { (Cb.api_client.new) }
 
     before(:each) do
-      cb_api_client.stub(:cb_get).and_return({ 'bananas' => '4life' })
-      Cb.api_client.stub(:new).and_return(cb_api_client)
+      allow(cb_api_client).to receive(:cb_get).and_return({ 'bananas' => '4life' })
+      allow(Cb.api_client).to receive(:new).and_return(cb_api_client)
       response = double(Responses::EmployeeTypes::Search)
-      response.stub(:class).and_return Responses::EmployeeTypes::Search
-      Responses::EmployeeTypes::Search.stub(:new).and_return(response)
+      allow(response).to receive(:class).and_return Responses::EmployeeTypes::Search
+      allow(Responses::EmployeeTypes::Search).to receive(:new).and_return(response)
     end
 
     context '#new' do
       it 'returns a type of Cb::Clients::EmployeeTypes' do
-        Clients::EmployeeTypes.new.class.should eq Cb::Clients::EmployeeTypes
+        expect(Clients::EmployeeTypes.new.class).to eq Cb::Clients::EmployeeTypes
       end
     end
 
     def returns_response_object(method, *args)
       response = client_under_test.send(method, *args)
-      response.class.should eq Responses::EmployeeTypes::Search
+      expect(response.class).to eq Responses::EmployeeTypes::Search
     end
 
     context '#search' do
       it 'calls the employee types endpoint' do
         endpoint_url = Cb.configuration.uri_employee_types
-        cb_api_client.should_receive(:cb_get).with(endpoint_url)
+        expect(cb_api_client).to receive(:cb_get).with(endpoint_url)
         client_under_test.search
       end
 
@@ -41,7 +41,7 @@ module Cb
         endpoint_url = Cb.configuration.uri_employee_types
         hostsite = 'de'
         query = { :query => { :CountryCode => hostsite } }
-        cb_api_client.should_receive(:cb_get).with(endpoint_url, query)
+        expect(cb_api_client).to receive(:cb_get).with(endpoint_url, query)
         client_under_test.search_by_hostsite(hostsite)
       end
 

--- a/spec/cb/clients/job_spec.rb
+++ b/spec/cb/clients/job_spec.rb
@@ -13,7 +13,7 @@ module Cb
 
         it 'returns an empty array' do
           response = Cb.job.search(Hash.new)
-          response.model.jobs.count.should == 0
+          expect(response.model.jobs.count).to eq(0)
         end
       end
 
@@ -36,7 +36,7 @@ module Cb
 
         it 'returns an empty array' do
           response = Cb.job.search(Hash.new)
-          response.model.jobs.count.should == 0
+          expect(response.model.jobs.count).to eq(0)
         end
       end
 
@@ -52,7 +52,7 @@ module Cb
 
         it 'returns an array of job models' do
           response = Cb.job.search(Hash.new)
-          response.model.jobs[0].is_a?(Cb::Models::Job).should == true
+          expect(response.model.jobs[0].is_a?(Cb::Models::Job)).to eq(true)
         end
       end
 
@@ -69,7 +69,7 @@ module Cb
 
         it 'returns an array of job models' do
           search = Cb.job.search(Hash.new)
-          search.model.jobs[0].should be_a Cb::Models::Job
+          expect(search.model.jobs[0]).to be_a Cb::Models::Job
         end
       end
 
@@ -134,14 +134,14 @@ module Cb
       context 'when a string job did is input' do
         let(:criteria) { double(Cb::Criteria::Job::Details) }
 
-        before(:each) { Cb::Criteria::Job::Details.stub(:new).and_return(criteria) }
+        before(:each) { allow(Cb::Criteria::Job::Details).to receive(:new).and_return(criteria) }
 
         it 'constructs a criteria object, sets the input did, and calls #find_by_criteria' do
           did = 'fake-did'
 
-          Cb::Clients::Job.should_receive(:find_by_criteria).with(criteria)
-          criteria.should_receive(:did=).with(did)
-          criteria.should_receive(:show_custom_values=).with(true)
+          expect(Cb::Clients::Job).to receive(:find_by_criteria).with(criteria)
+          expect(criteria).to receive(:did=).with(did)
+          expect(criteria).to receive(:show_custom_values=).with(true)
 
           Cb::Clients::Job.find_by_did(did)
         end

--- a/spec/cb/clients/recommendation_spec.rb
+++ b/spec/cb/clients/recommendation_spec.rb
@@ -9,17 +9,17 @@ module Cb
       it 'should get recommendations for a job using a hash' do
         recs = Cb.recommendation.for_job({ :JobDID => 'fake-did' })
 
-        recs[0].is_a?(Cb::Models::Job).should == true
-        recs.count.should > 0
-        recs.api_error.should == false
+        expect(recs[0].is_a?(Cb::Models::Job)).to eq(true)
+        expect(recs.count).to be > 0
+        expect(recs.api_error).to eq(false)
       end
 
       it 'should get recommendations for a job using the old way' do
         recs = Cb.recommendation.for_job('fake-did')
 
-        recs[0].is_a?(Cb::Models::Job).should == true
-        recs.count.should > 0
-        recs.api_error.should == false
+        expect(recs[0].is_a?(Cb::Models::Job)).to eq(true)
+        expect(recs.count).to be > 0
+        expect(recs.api_error).to eq(false)
       end
     end
 
@@ -43,18 +43,18 @@ module Cb
         test_user_external_id = 'XRHS30G60RWSQ5P1S8RG'
         recs = Cb.recommendation.for_user({ :ExternalID => test_user_external_id })
 
-        recs.count.should > 0
-        recs[0].is_a?(Cb::Models::Job).should == true
-        recs.api_error.should == false
+        expect(recs.count).to be > 0
+        expect(recs[0].is_a?(Cb::Models::Job)).to eq(true)
+        expect(recs.api_error).to eq(false)
       end
 
       it 'should get recommendations for a user using the old way' do
         test_user_external_id = 'XRHS30G60RWSQ5P1S8RG'
         recs = Cb.recommendation.for_user(test_user_external_id)
 
-        recs.count.should > 0
-        recs[0].is_a?(Cb::Models::Job).should == true
-        recs.api_error.should == false
+        expect(recs.count).to be > 0
+        expect(recs[0].is_a?(Cb::Models::Job)).to eq(true)
+        expect(recs.api_error).to eq(false)
       end
     end
 

--- a/spec/cb/clients/saved_search_spec.rb
+++ b/spec/cb/clients/saved_search_spec.rb
@@ -7,7 +7,7 @@ module Cb
     context '.new' do
       it 'should create a new saved job search api object' do
         saved_search_request = Cb::Clients::SavedSearch.new
-        saved_search_request.should be_a_kind_of(Cb::Clients::SavedSearch)
+        expect(saved_search_request).to be_a_kind_of(Cb::Clients::SavedSearch)
       end
     end
 
@@ -25,7 +25,7 @@ module Cb
                                          'ExternalUserID' => @external_user_id, 'SearchName' => search_name,
                                          'HostSite' => @host_site})
 
-        Cb.saved_search.new.create(model).class.should eq Responses::SavedSearch::Singular
+        expect(Cb.saved_search.new.create(model).class).to eq Responses::SavedSearch::Singular
       end
     end
 
@@ -48,7 +48,7 @@ module Cb
                                            'HostSite' => 'GR', 'userOAuthToken' => oauth})
 
           response = Cb.saved_search.new.update(model)
-          response.model.class.should eq Models::SavedSearch
+          expect(response.model.class).to eq Models::SavedSearch
         end
       end
 
@@ -71,7 +71,7 @@ module Cb
 
 
           response = Cb.saved_search.new.update(model)
-          response.model.class.should eq Models::SavedSearch
+          expect(response.model.class).to eq Models::SavedSearch
         end
       end
     end
@@ -84,7 +84,7 @@ module Cb
         it 'should return an array of saved searches' do
           user_saved_search = Cb.saved_search.new.list(@user_oauth_token, 'WR')
           expect(user_saved_search.models).to be_an_instance_of Array
-          user_saved_search.models.count.should == 2
+          expect(user_saved_search.models.count).to eq(2)
           expect(user_saved_search.models.first).to be_an_instance_of Cb::Models::SavedSearch
         end
       end
@@ -96,7 +96,7 @@ module Cb
         it 'should return an array of saved searches' do
           user_saved_search = Cb.saved_search.new.list(@user_oauth_token, 'WR')
           expect(user_saved_search.models).to be_an_instance_of Array
-          user_saved_search.models.count.should == 0
+          expect(user_saved_search.models.count).to eq(0)
         end
       end
     end
@@ -126,7 +126,7 @@ module Cb
 
       it 'should return a saved search model' do
         response = Cb::Clients::SavedSearch.new.retrieve(@user_oauth_token, 'xid')
-        response.model.should be_an_instance_of(Models::SavedSearch)
+        expect(response.model).to be_an_instance_of(Models::SavedSearch)
       end
     end
 

--- a/spec/cb/clients/spot_spec.rb
+++ b/spec/cb/clients/spot_spec.rb
@@ -8,8 +8,8 @@ module Cb
       api_client          = Clients::Spot.send(:api_client)
       the_same_api_client = Clients::Spot.send(:api_client)
 
-      api_client.should eq the_same_api_client
-      api_client.object_id.should eq the_same_api_client.object_id
+      expect(api_client).to eq the_same_api_client
+      expect(api_client.object_id).to eq the_same_api_client.object_id
     end
 
     describe '#retrieve' do
@@ -64,9 +64,9 @@ module Cb
       context 'when the API response is missing nodes' do
         def restub_mocked_api
           api = Cb::Utils::Api.new
-          api.class.stub(:criteria_to_hash)
-          api.stub(:cb_get).and_return(@fake_mangled_response)
-          Clients::Spot.stub(:api_client).and_return(api)
+          allow(api.class).to receive(:criteria_to_hash)
+          allow(api).to receive(:cb_get).and_return(@fake_mangled_response)
+          allow(Clients::Spot).to receive(:api_client).and_return(api)
         end
 
         def expect_fields_missing_exception

--- a/spec/cb/clients/talent_network_spec.rb
+++ b/spec/cb/clients/talent_network_spec.rb
@@ -12,7 +12,7 @@ module Cb
         valid_did = "JHL5ZF68B66TBD63Z62"
         job_info = Cb.talent_network.tn_job_information(valid_did)
         expect(job_info.class).to be == Cb::Models::TalentNetwork::JobInfo
-        job_info.api_error.should == false
+        expect(job_info.api_error).to eq(false)
       end
     end
 
@@ -25,8 +25,8 @@ module Cb
       it 'should retrieve the form questions given a valid tn DID' do 
         tn_did = 'CB000000000000000001'
         join_form = Cb.talent_network.join_form_questions(tn_did)
-        join_form.join_form_questions.size.should > 0
-        join_form.api_error.should == false
+        expect(join_form.join_form_questions.size).to be > 0
+        expect(join_form.api_error).to eq(false)
       end
     end
 
@@ -39,8 +39,8 @@ module Cb
       it 'should retrieve branding information for a valid tn DID' do
         tn_did = 'CB000000000000000001'
         join_form_branding_info = Cb.talent_network.join_form_branding(tn_did)
-        join_form_branding_info.nil?.should == false
-        join_form_branding_info.api_error.should == false
+        expect(join_form_branding_info.nil?).to eq(false)
+        expect(join_form_branding_info.api_error).to eq(false)
       end
     end
 
@@ -52,11 +52,11 @@ module Cb
 
       it 'should retrieve the geo dropdown list info for join form questions' do 
         join_form_geo = Cb.talent_network.join_form_geography
-        join_form_geo.nil?.should == false
+        expect(join_form_geo.nil?).to eq(false)
       
         join_form_geo.countries.geo_hash.length > 0
         join_form_geo.states.geo_hash.length > 0
-        join_form_geo.api_error.should == false
+        expect(join_form_geo.api_error).to eq(false)
       end
     end
 
@@ -78,9 +78,9 @@ module Cb
                                   "ddlCountries","us"]
 
         member = Cb.talent_network.member_create(args1)
-        member.cb_response.errors.first.should_not == "EmailInUse"
-        member.nil?.should_not == true
-        member.api_error.should == false
+        expect(member.cb_response.errors.first).not_to eq("EmailInUse")
+        expect(member.nil?).not_to eq(true)
+        expect(member.api_error).to eq(false)
       end
 
     end

--- a/spec/cb/clients/user_spec.rb
+++ b/spec/cb/clients/user_spec.rb
@@ -175,17 +175,20 @@ module Cb
     end
 
     describe '#delete' do
+      before { allow(Cb::Responses::User::Delete).to receive(:new).and_return('fake response') }
+      let(:api_response) do { 'ResponseUserDelete' => 'yeehaw' } end
+
       it 'builds xml correctly' do
         body = <<-eos
-        <?xml version="1.0"?>
-          <Request>
-            <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
-            <Password>pw</Password>
-            <ExternalID>ext_id</ExternalID>
-            <Test>true</Test>
-          </Request>
-        eos
-        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with(anything, body: body)
+<?xml version="1.0"?>
+<Request>
+  <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
+  <Password>pw</Password>
+  <ExternalID>ext_id</ExternalID>
+  <Test>true</Test>
+</Request>
+eos
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with(anything, body: body).and_return(api_response)
         Cb.user.delete(Cb::Criteria::User::Delete.new(external_id: 'ext_id', password: 'pw', test: true))
       end
     end

--- a/spec/cb/clients/user_spec.rb
+++ b/spec/cb/clients/user_spec.rb
@@ -46,49 +46,49 @@ module Cb
 
         context 'by interacting with the API client directly' do
           it 'returns a CheckExisting response' do
-            response.should be_a Responses::User::CheckExisting
+            expect(response).to be_a Responses::User::CheckExisting
           end
         end
 
         context 'When external id comes back' do
           it 'external_id should not be nil' do
-            response.model.external_id.should == 'abc123'
+            expect(response.model.external_id).to eq('abc123')
           end
         end
 
         context 'When ResponseTempPassword comes back' do
           it 'temp_password should be true' do
-            response.model.temp_password.should == true
+            expect(response.model.temp_password).to eq(true)
           end
         end
 
         context 'When oauth token comes back' do
           it 'oauth_token should not be nil' do
-            response.model.oauth_token.should == '456xyz'
+            expect(response.model.oauth_token).to eq('456xyz')
           end
         end
 
         context 'When partner id comes back' do
           it 'partner_id should not be nil' do
-            response.model.partner_id.should == 'zyx654'
+            expect(response.model.partner_id).to eq('zyx654')
           end
         end
 
         context 'When user check status comes back' do
           it 'status should not be nil' do
-            response.model.status.should == 'EmailExistsPasswordsDoNotMatch'
+            expect(response.model.status).to eq('EmailExistsPasswordsDoNotMatch')
           end
         end
 
         context 'When email comes back' do
           it 'email should not be nil' do
-            response.model.email.should == 'kyle@cb.gov'
+            expect(response.model.email).to eq('kyle@cb.gov')
           end
         end
 
         it 'builds xml correctly' do
-          Cb::Utils::Api.any_instance.should_receive(:cb_post).with do |uri, options|
-            options[:body].should eq <<-eos
+          expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with { |instance, uri, options|
+            expect(options[:body]).to eq <<-eos
             <Request>
               <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
               <Email>k@cb.com</Email>
@@ -96,7 +96,7 @@ module Cb
               <Test>false</Test>
             </Request>
             eos
-          end.and_return(JSON.parse(body.to_json))
+          }.and_return(JSON.parse(body.to_json))
 
           Cb.user.check_existing 'k@cb.com', 'moom'
         end
@@ -109,7 +109,7 @@ module Cb
 
         context 'When ResponseTempPassword comes back false' do
           it 'temp_password should be false' do
-            response.model.temp_password.should == false
+            expect(response.model.temp_password).to eq(false)
           end
         end
 
@@ -119,7 +119,7 @@ module Cb
           end
 
           it 'temp_password should be false' do
-            response.model.temp_password.should == false
+            expect(response.model.temp_password).to eq(false)
           end
         end
       end
@@ -139,7 +139,7 @@ module Cb
         expect(user.cb_response.errors.nil?).to be true
         expect(user.cb_response.status).to be == 'Success (Test)'
         expect(user.nil?).to be false
-        user.api_error.should == false
+        expect(user.api_error).to eq(false)
       end
     end
 
@@ -162,15 +162,15 @@ module Cb
 
     describe '#retrieve' do
       it 'builds xml correctly' do
-        Cb::Utils::Api.any_instance.should_receive(:cb_post).with do |uri, options|
-          options[:body].should eq <<-eos
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with { |instance, uri, options|
+          expect(options[:body]).to eq <<-eos
             <Request>
               <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
               <ExternalID>ext_id</ExternalID>
               <Test>true</Test>
             </Request>
           eos
-        end.and_return({})
+        }.and_return({})
 
         Cb.user.retrieve 'ext_id', true
       end
@@ -178,8 +178,8 @@ module Cb
 
     describe '#delete' do
       it 'builds xml correctly' do
-        Cb::Utils::Api.any_instance.should_receive(:cb_post).with do |uri, options|
-          options[:body].should eq <<-eos
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with { |instance, uri, options|
+          expect(options[:body]).to eq <<-eos
 <?xml version="1.0"?>
 <Request>
   <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
@@ -188,7 +188,7 @@ module Cb
   <Test>true</Test>
 </Request>
           eos
-        end.and_return({})
+        }.and_return({})
 
         Cb.user.delete(Cb::Criteria::User::Delete.new(external_id: 'ext_id', password: 'pw', test: true))
       end

--- a/spec/cb/clients/user_spec.rb
+++ b/spec/cb/clients/user_spec.rb
@@ -87,7 +87,7 @@ module Cb
         end
 
         it 'builds xml correctly' do
-          body = <<-eos
+          request_body = <<-eos
             <Request>
               <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
               <Email>k@cb.com</Email>
@@ -95,9 +95,7 @@ module Cb
               <Test>false</Test>
             </Request>
           eos
-          expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with(anything, body: body)
-                                                      .and_return(JSON.parse(body.to_json))
-
+          expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with(anything, body: request_body).and_call_original
           Cb.user.check_existing 'k@cb.com', 'moom'
         end
       end

--- a/spec/cb/clients/user_spec.rb
+++ b/spec/cb/clients/user_spec.rb
@@ -160,16 +160,17 @@ module Cb
     end
 
     describe '#retrieve' do
+      let(:api_response) do { 'ResponseUserInfo' => { 'UserInfo' => 'yeehaw' } } end
       it 'builds xml correctly' do
         body = <<-eos
-          <Request>
-            <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
-            <ExternalID>ext_id</ExternalID>
-            <Test>true</Test>
-          </Request>
+            <Request>
+              <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
+              <ExternalID>ext_id</ExternalID>
+              <Test>true</Test>
+            </Request>
         eos
 
-        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with(anything, body: body)
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with(anything, body: body).and_return(api_response)
         Cb.user.retrieve 'ext_id', true
       end
     end

--- a/spec/cb/clients/user_spec.rb
+++ b/spec/cb/clients/user_spec.rb
@@ -6,7 +6,6 @@ module Cb
     describe '#temporary_password' do
       before do
         stub_request(:get, uri_stem(Cb.configuration.uri_user_temp_password)).
-          with(:query => anything).
           to_return(:body => { Errors: [], TemporaryPassword: 'hotdogs!' }.to_json)
       end
 

--- a/spec/cb/clients/user_spec.rb
+++ b/spec/cb/clients/user_spec.rb
@@ -87,16 +87,16 @@ module Cb
         end
 
         it 'builds xml correctly' do
-          expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with { |instance, uri, options|
-            expect(options[:body]).to eq <<-eos
+          body = <<-eos
             <Request>
               <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
               <Email>k@cb.com</Email>
               <Password>moom</Password>
               <Test>false</Test>
             </Request>
-            eos
-          }.and_return(JSON.parse(body.to_json))
+          eos
+          expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with(anything, body: body)
+                                                      .and_return(JSON.parse(body.to_json))
 
           Cb.user.check_existing 'k@cb.com', 'moom'
         end
@@ -130,8 +130,8 @@ module Cb
     context '.retrieve' do
       before :each do
         stub_request(:post, uri_stem(Cb.configuration.uri_user_retrieve)).
-            with(:body => anything).
-            to_return(:body => { ResponseUserInfo: { Errors: nil, Status: 'Success (Test)', UserInfo: Hash.new } }.to_json)
+          with(:body => anything).
+          to_return(:body => { ResponseUserInfo: { Errors: nil, Status: 'Success (Test)', UserInfo: Hash.new } }.to_json)
       end
 
       it 'should retrieve a user' do
@@ -146,12 +146,11 @@ module Cb
     context '.delete' do
       before :each do
         stub_request(:post, uri_stem(Cb.configuration.uri_user_delete)).
-            with(:body => anything).
-            to_return(:body => { ResponseUserDelete: { Request: {}, Status: 'Success (Test)' } }.to_json)
+          with(:body => anything).
+          to_return(:body => { ResponseUserDelete: { Request: {}, Status: 'Success (Test)' } }.to_json)
       end
 
       it 'should delete a user', :vcr => { :cassette_name => 'user/delete/success' } do
-
         result = Cb.user.delete(Cb::Criteria::User::Delete.new(external_id: 'xid', password: 'passwort'))
 
         expect(result).to be_an_instance_of Cb::Responses::User::Delete
@@ -162,34 +161,31 @@ module Cb
 
     describe '#retrieve' do
       it 'builds xml correctly' do
-        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with { |instance, uri, options|
-          expect(options[:body]).to eq <<-eos
-            <Request>
-              <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
-              <ExternalID>ext_id</ExternalID>
-              <Test>true</Test>
-            </Request>
-          eos
-        }.and_return({})
+        body = <<-eos
+          <Request>
+            <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
+            <ExternalID>ext_id</ExternalID>
+            <Test>true</Test>
+          </Request>
+        eos
 
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with(anything, body: body)
         Cb.user.retrieve 'ext_id', true
       end
     end
 
     describe '#delete' do
       it 'builds xml correctly' do
-        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with { |instance, uri, options|
-          expect(options[:body]).to eq <<-eos
-<?xml version="1.0"?>
-<Request>
-  <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
-  <Password>pw</Password>
-  <ExternalID>ext_id</ExternalID>
-  <Test>true</Test>
-</Request>
-          eos
-        }.and_return({})
-
+        body = <<-eos
+        <?xml version="1.0"?>
+          <Request>
+            <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
+            <Password>pw</Password>
+            <ExternalID>ext_id</ExternalID>
+            <Test>true</Test>
+          </Request>
+        eos
+        expect_any_instance_of(Cb::Utils::Api).to receive(:cb_post).with(anything, body: body)
         Cb.user.delete(Cb::Criteria::User::Delete.new(external_id: 'ext_id', password: 'pw', test: true))
       end
     end
@@ -198,11 +194,11 @@ module Cb
       context 'When an user makes a change password request' do
         let(:user_info_change_password) {
           Cb::Criteria::User::ChangePassword.new({
-                                                external_id: '123TEST',
-                                                old_password: 'MyPassWord123',
-                                                new_password: 'MyNewPassword123',
-                                                test: 'false'
-                                            }) }
+                                                   external_id: '123TEST',
+                                                   old_password: 'MyPassWord123',
+                                                   new_password: 'MyNewPassword123',
+                                                   test: 'false'
+                                                 }) }
         let(:api_return_fail) do { 'ResponseUserChangePW' => { 'Request' => { 'ExternalID' => 'EXT12345', 'Errors' => 'An error occurred' }, 'Status' => 'Fail' } } end
         let(:api_return_success) do { 'ResponseUserChangePW' => { 'Request' => { 'ExternalID' => 'EXT12345', 'Errors' => '' }, 'Status' => 'Success' } } end
 

--- a/spec/cb/config_spec.rb
+++ b/spec/cb/config_spec.rb
@@ -6,18 +6,18 @@ module Cb
       it 'should return a hash' do
       	config = Cb.configuration
 
-      	config.is_a?(Cb::Config).should == true
-      	config.to_hash.is_a?(Hash).should == true
+      	expect(config.is_a?(Cb::Config)).to eq(true)
+      	expect(config.to_hash.is_a?(Hash)).to eq(true)
       end
     end
     context 'defaults' do
       it 'should have a base_uri' do
         config = Cb.configuration
-        config.base_uri.should_not be_nil
+        expect(config.base_uri).not_to be_nil
       end
       it 'should have a base_uri with https' do
         config = Cb.configuration
-        config.base_uri[0..4].should == 'https'
+        expect(config.base_uri[0..4]).to eq('https')
       end
     end
     context 'uri' do
@@ -27,10 +27,10 @@ module Cb
         default_uri = config.base_uri
 
         config.set_base_uri(uri)
-        config.base_uri.should == uri
+        expect(config.base_uri).to eq(uri)
 
         config.set_base_uri(default_uri)
-        config.base_uri.should == default_uri
+        expect(config.base_uri).to eq(default_uri)
       end
     end
   end

--- a/spec/cb/models/api_response_model_spec.rb
+++ b/spec/cb/models/api_response_model_spec.rb
@@ -31,7 +31,7 @@ module Cb
               ValidDummyModel.new(@api_response)
               raise 'test should not have made it this far!'
             rescue ExpectedResponseFieldMissing => ex
-              ex.message.include?('potatoes hotdogs baconbaconbacon').should eq true
+              expect(ex.message.include?('potatoes hotdogs baconbaconbacon')).to eq true
             end
           end
         end
@@ -45,7 +45,7 @@ module Cb
             expected_to_raise_error.call
             raise 'this test should not have made it this far!' # fail if proc code does not raise error
           rescue NotImplementedError => ex
-            ex.message.include?(method_name).should eq true
+            expect(ex.message.include?(method_name)).to eq true
           end
         end
 

--- a/spec/cb/models/implementations/application_form_spec.rb
+++ b/spec/cb/models/implementations/application_form_spec.rb
@@ -15,14 +15,14 @@ describe Cb::Models::Application::Form do
       model = Cb::Models::Application::Form.new(response_stub)
       expect(model.job_did).to eq 'JHT2*********'
       expect(model.job_title).to eq 'Licensed Practical Nurse - LPN (Nonprofit Social Services - Nursing)'
-      expect(model.is_shared_apply).to be_false
+      expect(model.is_shared_apply).to be_falsey
       expect(model.question_list).to be_an_instance_of Array
       expect(model.question_list.first).to be_an_instance_of Cb::Models::Application::Question
       expect(model.requirements).to eq 'Our ideal Licensed Practical Nurse has excellent listening**********'
       expect(model.degree_required).to eq '2 Year Degree'
       expect(model.travel_required).to eq 'Negligible'
       expect(model.experience_required).to eq 'Yay'
-      expect(model.external_application).to be_false
+      expect(model.external_application).to be_falsey
       expect(model.total_questions).to eq 11
       expect(model.total_required_questions).to eq 10
     end
@@ -33,7 +33,7 @@ describe Cb::Models::Application::Form do
       response_stub['QuestionList'] = ''
       model = Cb::Models::Application::Form.new(response_stub)
       expect(model.question_list).to be_an_instance_of Array
-      expect(model.question_list.empty?).to be_true
+      expect(model.question_list.empty?).to be_truthy
     end
   end
 
@@ -64,7 +64,7 @@ describe Cb::Models::Application::Form do
         question_stub['Answers'] = ''
         model = Cb::Models::Application::Question.new(question_stub)
         expect(model.answers).to be_an_instance_of Array
-        expect(model.answers.empty?).to be_true
+        expect(model.answers.empty?).to be_truthy
       end
     end
   end

--- a/spec/cb/models/implementations/application_spec.rb
+++ b/spec/cb/models/implementations/application_spec.rb
@@ -28,21 +28,21 @@ module Cb::Models
       context 'When IsSubmitted is nil' do
         let(:is_submitted) { nil }
         it 'sets is_submitted as false' do
-          expect(application.is_submitted).to be_false
+          expect(application.is_submitted).to be_falsey
         end
       end
 
       context 'When IsSubmitted is "true"' do
         let(:is_submitted) { "true" }
         it 'sets is_submitted as true' do
-          expect(application.is_submitted).to be_true
+          expect(application.is_submitted).to be_truthy
         end
       end
 
       context 'When IsSubmitted is "false"' do
         let(:is_submitted) { "false" }
         it 'sets is_submitted as true' do
-          expect(application.is_submitted).to be_false
+          expect(application.is_submitted).to be_falsey
         end
       end
     end

--- a/spec/cb/models/implementations/email_subscription_spec.rb
+++ b/spec/cb/models/implementations/email_subscription_spec.rb
@@ -18,10 +18,10 @@ module Cb::Models
 
 
 
-        subscription.career_resources.should == career_resources
-        subscription.product_sponsor_info.should == product_sponsor_info
-        subscription.applicant_survey_invites.should == applicant_survey_invites
-        subscription.job_recs.should == job_recs
+        expect(subscription.career_resources).to eq(career_resources)
+        expect(subscription.product_sponsor_info).to eq(product_sponsor_info)
+        expect(subscription.applicant_survey_invites).to eq(applicant_survey_invites)
+        expect(subscription.job_recs).to eq(job_recs)
 
       end
     end

--- a/spec/cb/models/implementations/employee_type_spec.rb
+++ b/spec/cb/models/implementations/employee_type_spec.rb
@@ -8,9 +8,9 @@ module Cb
         end
 
         it 'initializes with no args to empty string defaults' do
-          new_model.code.    should eq String.new
-          new_model.name.    should eq String.new
-          new_model.language.should eq String.new
+          expect(new_model.code).    to eq String.new
+          expect(new_model.name).    to eq String.new
+          expect(new_model.language).to eq String.new
         end
       end
 
@@ -24,9 +24,9 @@ module Cb
         end
 
         it 'initializes with the values of those fields' do
-          new_model(populated_input).code.    should eq 'whoa'
-          new_model(populated_input).name.    should eq 'weird'
-          new_model(populated_input).language.should eq 'formatting'
+          expect(new_model(populated_input).code).    to eq 'whoa'
+          expect(new_model(populated_input).name).    to eq 'weird'
+          expect(new_model(populated_input).language).to eq 'formatting'
         end
       end
     end

--- a/spec/cb/models/implementations/job_branding_spec.rb
+++ b/spec/cb/models/implementations/job_branding_spec.rb
@@ -106,58 +106,58 @@ module Cb::Models
                 'CompanyDescription' => company_description
 	        })
 
-        job_branding.name.should == name
-        job_branding.id.should == id
-        job_branding.account_id.should == account_id
-        job_branding.type.should == type
-        job_branding.errors.should == errors
+        expect(job_branding.name).to eq(name)
+        expect(job_branding.id).to eq(id)
+        expect(job_branding.account_id).to eq(account_id)
+        expect(job_branding.type).to eq(type)
+        expect(job_branding.errors).to eq(errors)
         job_branding.company_description = company_description
-        job_branding.show_widgets.should == (widgets['ShowWidgets'] == 'true')
+        expect(job_branding.show_widgets).to eq(widgets['ShowWidgets'] == 'true')
 
-        job_branding.media.header.should == media['Header']
-        job_branding.media.header_type.should == media['HeaderType']
-        job_branding.media.tablet_banner.should == media['TabletBanner']
-        job_branding.media.mobile_logo.should == media['MobileLogo']
-        job_branding.media.footer.should == media['Footer']
-        job_branding.media.is_multi_video.should == (media['IsMultiVideo'] == 'true')
+        expect(job_branding.media.header).to eq(media['Header'])
+        expect(job_branding.media.header_type).to eq(media['HeaderType'])
+        expect(job_branding.media.tablet_banner).to eq(media['TabletBanner'])
+        expect(job_branding.media.mobile_logo).to eq(media['MobileLogo'])
+        expect(job_branding.media.footer).to eq(media['Footer'])
+        expect(job_branding.media.is_multi_video).to eq(media['IsMultiVideo'] == 'true')
 
-        job_branding.sections.count.should == 2
-        job_branding.sections[0].type.should == sections.keys[0]
-        job_branding.sections[0].section_1.should == sections['Page']['Section1']
-        job_branding.sections[0].section_2.should == sections['Page']['Section2']
-        job_branding.sections[0].section_3.should == sections['Page']['Section3']
-        job_branding.sections[0].description.should == ''
-        job_branding.sections[0].requirements.should == ''
-        job_branding.sections[0].snapshot.should == ''
-        job_branding.sections[1].type.should == sections.keys[1]
-        job_branding.sections[1].section_1.should == ''
-        job_branding.sections[1].section_2.should == ''
-        job_branding.sections[1].section_3.should == ''
-        job_branding.sections[1].description.should == sections['JobDetails']['Description']
-        job_branding.sections[1].requirements.should == sections['JobDetails']['Requirements']
-        job_branding.sections[1].snapshot.should == sections['JobDetails']['Snapshot']
+        expect(job_branding.sections.count).to eq(2)
+        expect(job_branding.sections[0].type).to eq(sections.keys[0])
+        expect(job_branding.sections[0].section_1).to eq(sections['Page']['Section1'])
+        expect(job_branding.sections[0].section_2).to eq(sections['Page']['Section2'])
+        expect(job_branding.sections[0].section_3).to eq(sections['Page']['Section3'])
+        expect(job_branding.sections[0].description).to eq('')
+        expect(job_branding.sections[0].requirements).to eq('')
+        expect(job_branding.sections[0].snapshot).to eq('')
+        expect(job_branding.sections[1].type).to eq(sections.keys[1])
+        expect(job_branding.sections[1].section_1).to eq('')
+        expect(job_branding.sections[1].section_2).to eq('')
+        expect(job_branding.sections[1].section_3).to eq('')
+        expect(job_branding.sections[1].description).to eq(sections['JobDetails']['Description'])
+        expect(job_branding.sections[1].requirements).to eq(sections['JobDetails']['Requirements'])
+        expect(job_branding.sections[1].snapshot).to eq(sections['JobDetails']['Snapshot'])
 
-        job_branding.styles.page.raw.should == styles['Page']
-        job_branding.styles.page.to_css.should == 'color:#FFF;font-size:14px;font-family:Helvetica;'
-        job_branding.styles.job_details.raw.should == styles['JobDetails']
-        job_branding.styles.job_details.container.raw.should == styles['JobDetails']['Container']
-        job_branding.styles.job_details.container.to_css.should == 'border-color:#FFA;'
-        job_branding.styles.job_details.content.raw.should == styles['JobDetails']['Content']
-        job_branding.styles.job_details.content.to_css.should == '-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;'
-        job_branding.styles.job_details.headings.raw.should == styles['JobDetails']['Headings']
-        job_branding.styles.job_details.headings.to_css.should == '-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none;'
-        job_branding.styles.company_info.raw.should == styles['CompanyInfo']
-        job_branding.styles.company_info.buttons.raw.should == styles['CompanyInfo']['Buttons']
-        job_branding.styles.company_info.buttons.to_css.should == 'background-color:#CCC;'
-        job_branding.styles.company_info.container.raw.should == styles['CompanyInfo']['Container']
-        job_branding.styles.company_info.container.to_css.should == 'background-image:url(http://image.is.here/23242.jpg);'
-        job_branding.styles.company_info.content.raw.should == styles['CompanyInfo']['Content']
-        job_branding.styles.company_info.content.to_css.should == "background:#F2323A;background:-moz-linear-gradient(left,#F2323A0%,#D245A2100%);background:-webkit-gradient(linear,lefttop,righttop,color-stop(0%,#F2323A),color-stop(100%,#D245A2));background:-webkit-linear-gradient(left,#F2323A0%,#D245A2100%);background:-o-linear-gradient(left,#F2323A0%,#D245A2100%);background:-ms-linear-gradient(left,#F2323A0%,#D245A2100%);background:linear-gradient(toright,#F2323A0%,#D245A2100%);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#F2323A',endColorstr='#D245A2',GradientType=1);"
-        job_branding.styles.company_info.headings.raw.should == styles['CompanyInfo']['Headings']
-        job_branding.styles.company_info.headings.to_css.should == 'border-width:3px;'
+        expect(job_branding.styles.page.raw).to eq(styles['Page'])
+        expect(job_branding.styles.page.to_css).to eq('color:#FFF;font-size:14px;font-family:Helvetica;')
+        expect(job_branding.styles.job_details.raw).to eq(styles['JobDetails'])
+        expect(job_branding.styles.job_details.container.raw).to eq(styles['JobDetails']['Container'])
+        expect(job_branding.styles.job_details.container.to_css).to eq('border-color:#FFA;')
+        expect(job_branding.styles.job_details.content.raw).to eq(styles['JobDetails']['Content'])
+        expect(job_branding.styles.job_details.content.to_css).to eq('-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;')
+        expect(job_branding.styles.job_details.headings.raw).to eq(styles['JobDetails']['Headings'])
+        expect(job_branding.styles.job_details.headings.to_css).to eq('-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none;')
+        expect(job_branding.styles.company_info.raw).to eq(styles['CompanyInfo'])
+        expect(job_branding.styles.company_info.buttons.raw).to eq(styles['CompanyInfo']['Buttons'])
+        expect(job_branding.styles.company_info.buttons.to_css).to eq('background-color:#CCC;')
+        expect(job_branding.styles.company_info.container.raw).to eq(styles['CompanyInfo']['Container'])
+        expect(job_branding.styles.company_info.container.to_css).to eq('background-image:url(http://image.is.here/23242.jpg);')
+        expect(job_branding.styles.company_info.content.raw).to eq(styles['CompanyInfo']['Content'])
+        expect(job_branding.styles.company_info.content.to_css).to eq("background:#F2323A;background:-moz-linear-gradient(left,#F2323A0%,#D245A2100%);background:-webkit-gradient(linear,lefttop,righttop,color-stop(0%,#F2323A),color-stop(100%,#D245A2));background:-webkit-linear-gradient(left,#F2323A0%,#D245A2100%);background:-o-linear-gradient(left,#F2323A0%,#D245A2100%);background:-ms-linear-gradient(left,#F2323A0%,#D245A2100%);background:linear-gradient(toright,#F2323A0%,#D245A2100%);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#F2323A',endColorstr='#D245A2',GradientType=1);")
+        expect(job_branding.styles.company_info.headings.raw).to eq(styles['CompanyInfo']['Headings'])
+        expect(job_branding.styles.company_info.headings.to_css).to eq('border-width:3px;')
 
-        job_branding.widgets[0].type.should == widgets.keys[1]
-        job_branding.widgets[0].url.should == widgets.values[1]
+        expect(job_branding.widgets[0].type).to eq(widgets.keys[1])
+        expect(job_branding.widgets[0].url).to eq(widgets.values[1])
       end
     end
   end

--- a/spec/cb/models/implementations/job_spec.rb
+++ b/spec/cb/models/implementations/job_spec.rb
@@ -11,7 +11,7 @@ module Cb::Models
 
         it 'then the apply_requirements field should be set' do
           job = Job.new job_hash
-          job.apply_requirements.should == ['noonlineapply']
+          expect(job.apply_requirements).to eq(['noonlineapply'])
         end
 
       end
@@ -40,7 +40,7 @@ module Cb::Models
               it 'should respond true' do
                 job_hash = { response_field_name => 'True' }
                 job = Job.new(job_hash)
-                expect(job.send(predicate_method)).to be_true
+                expect(job.send(predicate_method)).to be_truthy
               end
             end
 
@@ -48,7 +48,7 @@ module Cb::Models
               it 'should response false' do
                 job_hash = { response_field_name => 'False' }
                 job = Job.new(job_hash)
-                expect(job.send(predicate_method)).to be_false
+                expect(job.send(predicate_method)).to be_falsey
               end
             end
           end
@@ -57,7 +57,7 @@ module Cb::Models
             it 'returns false' do
               job_hash = Hash.new
               job = Job.new(job_hash)
-              expect(job.send(predicate_method)).to be_false
+              expect(job.send(predicate_method)).to be_falsey
             end
           end
         end

--- a/spec/cb/models/implementations/recommended_job_spec.rb
+++ b/spec/cb/models/implementations/recommended_job_spec.rb
@@ -10,7 +10,7 @@ module Cb::Models
 
         it 'then the apply_requirements field should be set' do
           job = Job.new job_hash
-          job.apply_requirements.should == ['noonlineapply']
+          expect(job.apply_requirements).to eq(['noonlineapply'])
         end
       end
     end

--- a/spec/cb/models/implementations/saved_search_spec.rb
+++ b/spec/cb/models/implementations/saved_search_spec.rb
@@ -20,47 +20,47 @@ module Cb
                                                         'HostSite'=>host_site,
                                                         'SearchParameters'=>mock_search_parameters_response)
           
-          user_saved_search.should be_a_kind_of(Cb::Models::SavedSearch)
-          user_saved_search.is_daily_email.should == is_daily_email
-          user_saved_search.host_site.should == host_site
-          user_saved_search.search_name.should == search_name
-          user_saved_search.external_user_id.should == external_user_id
-          user_saved_search.did.should == did
-          user_saved_search.search_parameters.should be_a Cb::Models::SavedSearch::SearchParameters
+          expect(user_saved_search).to be_a_kind_of(Cb::Models::SavedSearch)
+          expect(user_saved_search.is_daily_email).to eq(is_daily_email)
+          expect(user_saved_search.host_site).to eq(host_site)
+          expect(user_saved_search.search_name).to eq(search_name)
+          expect(user_saved_search.external_user_id).to eq(external_user_id)
+          expect(user_saved_search.did).to eq(did)
+          expect(user_saved_search.search_parameters).to be_a Cb::Models::SavedSearch::SearchParameters
         end
 
         it 'should create a search parameter ' do
           saved_search_parameters = Cb::Models::SavedSearch::SearchParameters.new(mock_search_parameters_response)
 
-          saved_search_parameters.boolean_operator.should       == "BooleanOperator"
-          saved_search_parameters.category.should               == "Category"
-          saved_search_parameters.city.should                   == "City"
-          saved_search_parameters.company.should                == "Company"
-          saved_search_parameters.country.should                == "Country"
-          saved_search_parameters.education_code.should         == "EducationCode"
-          saved_search_parameters.emp_type.should               == "EmpType"
-          saved_search_parameters.exclude_company_names.should  == "ExcludeCompanyNames"
-          saved_search_parameters.exclude_job_titles.should     == "ExcludeJobTitles"
-          saved_search_parameters.exclude_keywords.should       == "ExcludeKeywords"
-          saved_search_parameters.exclude_national.should       == "ExcludeNational"
-          saved_search_parameters.industry_codes.should         == "IndustryCodes"
-          saved_search_parameters.jc_advertiser_flags.should    == "JCAdvertiserFlags"
-          saved_search_parameters.jc_job_nature.should          == "JCJobNature"
-          saved_search_parameters.jc_location.should            == "JCLocation"
-          saved_search_parameters.jc_position_level.should      == "JCPositionLevel"
-          saved_search_parameters.job_category.should           == ""
-          saved_search_parameters.job_title.should              == "JobTitle"
-          saved_search_parameters.keywords.should               == "Keywords"
-          saved_search_parameters.location.should               == "Location"
-          saved_search_parameters.order_by.should               == "OrderBy"
-          saved_search_parameters.order_direction.should        == "OrderDirection"
-          saved_search_parameters.pay_high.should               == "PayHigh"
-          saved_search_parameters.pay_info_only.should          == "PayInfoOnly"
-          saved_search_parameters.pay_low.should                == "PayLow"
-          saved_search_parameters.posted_within.should          == "PostedWithin"
-          saved_search_parameters.radius.should                 == "Radius"
-          saved_search_parameters.specific_education.should     == "SpecificEducation"
-          saved_search_parameters.state.should                  == "State"
+          expect(saved_search_parameters.boolean_operator).to       eq("BooleanOperator")
+          expect(saved_search_parameters.category).to               eq("Category")
+          expect(saved_search_parameters.city).to                   eq("City")
+          expect(saved_search_parameters.company).to                eq("Company")
+          expect(saved_search_parameters.country).to                eq("Country")
+          expect(saved_search_parameters.education_code).to         eq("EducationCode")
+          expect(saved_search_parameters.emp_type).to               eq("EmpType")
+          expect(saved_search_parameters.exclude_company_names).to  eq("ExcludeCompanyNames")
+          expect(saved_search_parameters.exclude_job_titles).to     eq("ExcludeJobTitles")
+          expect(saved_search_parameters.exclude_keywords).to       eq("ExcludeKeywords")
+          expect(saved_search_parameters.exclude_national).to       eq("ExcludeNational")
+          expect(saved_search_parameters.industry_codes).to         eq("IndustryCodes")
+          expect(saved_search_parameters.jc_advertiser_flags).to    eq("JCAdvertiserFlags")
+          expect(saved_search_parameters.jc_job_nature).to          eq("JCJobNature")
+          expect(saved_search_parameters.jc_location).to            eq("JCLocation")
+          expect(saved_search_parameters.jc_position_level).to      eq("JCPositionLevel")
+          expect(saved_search_parameters.job_category).to           eq("")
+          expect(saved_search_parameters.job_title).to              eq("JobTitle")
+          expect(saved_search_parameters.keywords).to               eq("Keywords")
+          expect(saved_search_parameters.location).to               eq("Location")
+          expect(saved_search_parameters.order_by).to               eq("OrderBy")
+          expect(saved_search_parameters.order_direction).to        eq("OrderDirection")
+          expect(saved_search_parameters.pay_high).to               eq("PayHigh")
+          expect(saved_search_parameters.pay_info_only).to          eq("PayInfoOnly")
+          expect(saved_search_parameters.pay_low).to                eq("PayLow")
+          expect(saved_search_parameters.posted_within).to          eq("PostedWithin")
+          expect(saved_search_parameters.radius).to                 eq("Radius")
+          expect(saved_search_parameters.specific_education).to     eq("SpecificEducation")
+          expect(saved_search_parameters.state).to                  eq("State")
         end
 
       end

--- a/spec/cb/models/implementations/talent_network_spec.rb
+++ b/spec/cb/models/implementations/talent_network_spec.rb
@@ -10,7 +10,7 @@ module Cb::Models
 
       it 'should return no join questions on create' do 
         tn_obj = TalentNetwork.new
-        tn_obj.join_form_questions.size.should == 0
+        expect(tn_obj.join_form_questions.size).to eq(0)
       end
 
       it 'should return at least one join question' do 
@@ -27,7 +27,7 @@ module Cb::Models
         ]
 
         tn_obj = TalentNetwork.new(args)
-        tn_obj.join_form_questions.size.should > 0
+        expect(tn_obj.join_form_questions.size).to be > 0
       end
     end
   end
@@ -58,12 +58,12 @@ module Cb::Models
 
       it 'should return empty tn questions when no args supplied' do 
         q_obj = TalentNetwork::Questions.new
-        q_obj.text.should == ''
-        q_obj.form_value.should == ''
-        q_obj.option_display_type.should == ''
-        q_obj.order.should == ''
-        q_obj.required.should == ''
-        q_obj.options.size.should == 0
+        expect(q_obj.text).to eq('')
+        expect(q_obj.form_value).to eq('')
+        expect(q_obj.option_display_type).to eq('')
+        expect(q_obj.order).to eq('')
+        expect(q_obj.required).to eq('')
+        expect(q_obj.options.size).to eq(0)
       end
 
       it 'should return tn questions supplied into args' do 
@@ -74,12 +74,12 @@ module Cb::Models
 
         q_obj = TalentNetwork::Questions.new(args)
         
-        q_obj.text.should == args['Text']
-        q_obj.form_value.should == args['FormValue']
-        q_obj.option_display_type.should == args['OptionDisplayType']
-        q_obj.order.should == ''
-        q_obj.required.should == ''
-        q_obj.options.size.should == 0
+        expect(q_obj.text).to eq(args['Text'])
+        expect(q_obj.form_value).to eq(args['FormValue'])
+        expect(q_obj.option_display_type).to eq(args['OptionDisplayType'])
+        expect(q_obj.order).to eq('')
+        expect(q_obj.required).to eq('')
+        expect(q_obj.options.size).to eq(0)
       end
 
       it 'should return at least one tn option' do
@@ -93,7 +93,7 @@ module Cb::Models
         ]
 
         q_obj = TalentNetwork::Questions.new(args)
-        q_obj.options.size.should > 0
+        expect(q_obj.options.size).to be > 0
       end
     end
   end
@@ -107,9 +107,9 @@ module Cb::Models
 
       it 'should return empty tn options when no args supplied' do
         opt_obj = TalentNetwork::Options.new
-        opt_obj.value.should == ''
-        opt_obj.order.should == ''
-        opt_obj.display_text.should == ''
+        expect(opt_obj.value).to eq('')
+        expect(opt_obj.order).to eq('')
+        expect(opt_obj.display_text).to eq('')
       end
 
       it 'should return tn options when args supplied' do 
@@ -118,9 +118,9 @@ module Cb::Models
         args['Order'] = 'Ascending'
 
         opt_obj = TalentNetwork::Options.new(args)
-        opt_obj.value.should == args['Value']
-        opt_obj.order.should == args['Order']
-        opt_obj.display_text.should == ''
+        expect(opt_obj.value).to eq(args['Value'])
+        expect(opt_obj.order).to eq(args['Order'])
+        expect(opt_obj.display_text).to eq('')
       end
     end
   end
@@ -134,9 +134,9 @@ module Cb::Models
 
       it 'should return empty job info when no args supplied' do 
         jinfo_obj = TalentNetwork::JobInfo.new
-        jinfo_obj.join_form_url.should == ''
-        jinfo_obj.tn_did.should == ''
-        jinfo_obj.join_form_intercept_enabled.should == ''
+        expect(jinfo_obj.join_form_url).to eq('')
+        expect(jinfo_obj.tn_did).to eq('')
+        expect(jinfo_obj.join_form_intercept_enabled).to eq('')
       end
 
       it 'should return job information when args supplied' do 
@@ -144,9 +144,9 @@ module Cb::Models
         args['sTNDID'] = 'SomeJobDID'
 
         jinfo_obj = TalentNetwork::JobInfo.new(args)
-        jinfo_obj.join_form_url.should == ''
-        jinfo_obj.tn_did.should == args['sTNDID']
-        jinfo_obj.join_form_intercept_enabled.should == ''
+        expect(jinfo_obj.join_form_url).to eq('')
+        expect(jinfo_obj.tn_did).to eq(args['sTNDID'])
+        expect(jinfo_obj.join_form_intercept_enabled).to eq('')
       end
     end
   end
@@ -160,8 +160,8 @@ module Cb::Models
 
       it 'should return empty countries and states when no args supplied' do
         jfgeo_obj = TalentNetwork::JoinFormGeo.new
-        jfgeo_obj.countries.size.should == 0
-        jfgeo_obj.states.size.should == 0
+        expect(jfgeo_obj.countries.size).to eq(0)
+        expect(jfgeo_obj.states.size).to eq(0)
       end
 
       it 'should return countries and states as a hash when args supplied' do 
@@ -176,8 +176,8 @@ module Cb::Models
         }
 
         jfgeo_obj = TalentNetwork::JoinFormGeo.new(args)
-        jfgeo_obj.countries.geo_hash.length.should > 0
-        jfgeo_obj.states.geo_hash.length.should > 0
+        expect(jfgeo_obj.countries.geo_hash.length).to be > 0
+        expect(jfgeo_obj.states.geo_hash.length).to be > 0
       end
     end
   end
@@ -191,7 +191,7 @@ module Cb::Models
 
       it 'should return empty geo hash when no args supplied' do 
         jfgl_obj = TalentNetwork::JoinFormGeoLocation.new
-        jfgl_obj.geo_hash.length.should == 0
+        expect(jfgl_obj.geo_hash.length).to eq(0)
       end
 
       it 'should return a filled hash when args are supplied' do 
@@ -199,7 +199,7 @@ module Cb::Models
         args['Value'] = ['aa', 'bb', 'cc']
         args['Display'] = ['aaa', 'bbb', 'ccc']
         jfgl_obj = TalentNetwork::JoinFormGeoLocation.new(args)
-        jfgl_obj.geo_hash.length.should > 0
+        expect(jfgl_obj.geo_hash.length).to be > 0
       end
     end
   end
@@ -213,13 +213,13 @@ module Cb::Models
 
       it 'should return no branding information when args are not supplied' do 
         jfb_obj = TalentNetwork::JoinFormBranding.new
-        jfb_obj.stylesheet_url.should == ''
-        jfb_obj.join_logo_image_url.should == ''
-        jfb_obj.join_custom_msg_html.should == ''
-        jfb_obj.button_color.should == ''
-        jfb_obj.mobile_logo_image_url.should == ''
-        jfb_obj.nav_color.should == ''
-        jfb_obj.site_path.should == ''
+        expect(jfb_obj.stylesheet_url).to eq('')
+        expect(jfb_obj.join_logo_image_url).to eq('')
+        expect(jfb_obj.join_custom_msg_html).to eq('')
+        expect(jfb_obj.button_color).to eq('')
+        expect(jfb_obj.mobile_logo_image_url).to eq('')
+        expect(jfb_obj.nav_color).to eq('')
+        expect(jfb_obj.site_path).to eq('')
       end
 
       it 'should return branding info when args supplied' do 
@@ -228,13 +228,13 @@ module Cb::Models
         args['JoinLogoImageURL'] = 'https://secure.com/my.png'
 
         jfb_obj = TalentNetwork::JoinFormBranding.new(args)
-        jfb_obj.stylesheet_url.should == args['StylesheetURL']
-        jfb_obj.join_logo_image_url.should == args['JoinLogoImageURL']
-        jfb_obj.join_custom_msg_html.should == ''
-        jfb_obj.button_color.should == ''
-        jfb_obj.mobile_logo_image_url.should == ''
-        jfb_obj.nav_color.should == ''
-        jfb_obj.site_path.should == ''
+        expect(jfb_obj.stylesheet_url).to eq(args['StylesheetURL'])
+        expect(jfb_obj.join_logo_image_url).to eq(args['JoinLogoImageURL'])
+        expect(jfb_obj.join_custom_msg_html).to eq('')
+        expect(jfb_obj.button_color).to eq('')
+        expect(jfb_obj.mobile_logo_image_url).to eq('')
+        expect(jfb_obj.nav_color).to eq('')
+        expect(jfb_obj.site_path).to eq('')
       end
     end
   end

--- a/spec/cb/requests/anonymous_saved_search/create_spec.rb
+++ b/spec/cb/requests/anonymous_saved_search/create_spec.rb
@@ -8,20 +8,20 @@ module Cb
         before(:each) { @request = Cb::Requests::AnonymousSavedSearch::Create.new({}) }
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_anon_saved_search_create
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_anon_saved_search_create)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == <<-eos
+          expect(@request.body).to eq <<-eos
           <Request>
             <HostSite></HostSite>
             <Cobrand></Cobrand>
@@ -76,20 +76,20 @@ module Cb
         end
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_anon_saved_search_create
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_anon_saved_search_create)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == <<-eos
+          expect(@request.body).to eq <<-eos
           <Request>
             <HostSite>host site</HostSite>
             <Cobrand>cobrand</Cobrand>

--- a/spec/cb/requests/anonymous_saved_search/delete_spec.rb
+++ b/spec/cb/requests/anonymous_saved_search/delete_spec.rb
@@ -8,20 +8,20 @@ module Cb
         before(:each) { @request = Cb::Requests::AnonymousSavedSearch::Delete.new({}) }
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_anon_saved_search_delete
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_anon_saved_search_delete)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == <<-eos
+          expect(@request.body).to eq <<-eos
           <Request>
             <ExternalID></ExternalID>
             <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
@@ -40,20 +40,20 @@ module Cb
         end
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_anon_saved_search_delete
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_anon_saved_search_delete)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == <<-eos
+          expect(@request.body).to eq <<-eos
           <Request>
             <ExternalID>external id</ExternalID>
             <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>

--- a/spec/cb/requests/application/create_spec.rb
+++ b/spec/cb/requests/application/create_spec.rb
@@ -8,24 +8,24 @@ module Cb
         before(:each) { @request = Cb::Requests::Application::Create.new({}) }
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_application_create
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_application_create)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == {
+          expect(@request.headers).to eq({
             'DeveloperKey' => Cb.configuration.dev_key,
             'HostSite' => Cb.configuration.host_site,
             'Content-Type' => 'application/json'
-          }
+          })
         end
 
         it 'should have a basic body' do
-          @request.body.should ==
+          expect(@request.body).to eq(
             {
               JobDID: nil,
               IsSubmitted: nil,
@@ -41,6 +41,7 @@ module Cb
               Responses: [],
               Test: 'false'
             }.to_json
+          )
         end
       end
 
@@ -86,24 +87,24 @@ module Cb
         end
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_application_create
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_application_create)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == {
+          expect(@request.headers).to eq({
             'DeveloperKey' => Cb.configuration.dev_key,
             'HostSite' => 'GR',
             'Content-Type' => 'application/json'
-          }
+          })
         end
 
         it 'should have a basic body' do
-          @request.body.should ==
+          expect(@request.body).to eq(
             {
               JobDID: 'job did',
               IsSubmitted: 'is submitted',
@@ -142,6 +143,7 @@ module Cb
               ],
               Test: 'true'
             }.to_json
+          )
         end
       end
     end

--- a/spec/cb/requests/application/form_spec.rb
+++ b/spec/cb/requests/application/form_spec.rb
@@ -8,24 +8,24 @@ module Cb
         before(:each) { @request = Cb::Requests::Application::Form.new({}) }
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_application_form.sub(':did', '')
-          @request.http_method.should == :get
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_application_form.sub(':did', ''))
+          expect(@request.http_method).to eq(:get)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == {
+          expect(@request.headers).to eq({
             'DeveloperKey' => Cb.configuration.dev_key,
             'HostSite' => Cb.configuration.host_site,
             'Content-Type' => 'application/json'
-          }
+          })
         end
 
         it 'should have a basic body' do
-          @request.body.should == nil
+          expect(@request.body).to eq(nil)
         end
       end
 
@@ -37,24 +37,24 @@ module Cb
         end
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_application_form.sub(':did', 'app did')
-          @request.http_method.should == :get
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_application_form.sub(':did', 'app did'))
+          expect(@request.http_method).to eq(:get)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == {
+          expect(@request.headers).to eq({
             'DeveloperKey' => Cb.configuration.dev_key,
             'HostSite' => Cb.configuration.host_site,
             'Content-Type' => 'application/json'
-          }
+          })
         end
 
         it 'should have a basic body' do
-          @request.body.should == nil
+          expect(@request.body).to eq(nil)
         end
       end
     end

--- a/spec/cb/requests/application/get_spec.rb
+++ b/spec/cb/requests/application/get_spec.rb
@@ -8,24 +8,24 @@ module Cb
         before(:each) { @request = Cb::Requests::Application::Get.new({}) }
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_application.sub(':did', '')
-          @request.http_method.should == :get
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_application.sub(':did', ''))
+          expect(@request.http_method).to eq(:get)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == {
+          expect(@request.headers).to eq({
             'DeveloperKey' => Cb.configuration.dev_key,
             'HostSite' => Cb.configuration.host_site,
             'Content-Type' => 'application/json'
-          }
+          })
         end
 
         it 'should have a basic body' do
-          @request.body.should == nil
+          expect(@request.body).to eq(nil)
         end
       end
 
@@ -37,24 +37,24 @@ module Cb
         end
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_application.sub(':did', 'app did')
-          @request.http_method.should == :get
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_application.sub(':did', 'app did'))
+          expect(@request.http_method).to eq(:get)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == {
+          expect(@request.headers).to eq({
             'DeveloperKey' => Cb.configuration.dev_key,
             'HostSite' => Cb.configuration.host_site,
             'Content-Type' => 'application/json'
-          }
+          })
         end
 
         it 'should have a basic body' do
-          @request.body.should == nil
+          expect(@request.body).to eq(nil)
         end
       end
     end

--- a/spec/cb/requests/application/update_spec.rb
+++ b/spec/cb/requests/application/update_spec.rb
@@ -8,24 +8,24 @@ module Cb
         before(:each) { @request = Cb::Requests::Application::Update.new({}) }
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_application.sub(':did', '')
-          @request.http_method.should == :put
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_application.sub(':did', ''))
+          expect(@request.http_method).to eq(:put)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == {
+          expect(@request.headers).to eq({
             'DeveloperKey' => Cb.configuration.dev_key,
             'HostSite' => Cb.configuration.host_site,
             'Content-Type' => 'application/json'
-          }
+          })
         end
 
         it 'should have a basic body' do
-          @request.body.should ==
+          expect(@request.body).to eq(
             {
               ApplicationDID: nil,
               JobDID: nil,
@@ -42,6 +42,7 @@ module Cb
               Responses: [],
               Test: 'false'
             }.to_json
+          )
         end
       end
 
@@ -87,24 +88,24 @@ module Cb
         end
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_application.sub(':did', 'app did')
-          @request.http_method.should == :put
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_application.sub(':did', 'app did'))
+          expect(@request.http_method).to eq(:put)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == {
+          expect(@request.headers).to eq({
             'DeveloperKey' => Cb.configuration.dev_key,
             'HostSite' => Cb.configuration.host_site,
             'Content-Type' => 'application/json'
-          }
+          })
         end
 
         it 'should have a basic body' do
-          @request.body.should ==
+          expect(@request.body).to eq(
             {
               ApplicationDID: 'app did',
               JobDID: 'job did',
@@ -144,6 +145,7 @@ module Cb
               ],
               Test: 'true'
             }.to_json
+          )
         end
       end
     end

--- a/spec/cb/requests/application_external/submit_application_spec.rb
+++ b/spec/cb/requests/application_external/submit_application_spec.rb
@@ -8,20 +8,20 @@ module Cb
         before(:each) { @request = Cb::Requests::ApplicationExternal::SubmitApplication.new({}) }
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_application_external
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_application_external)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == <<-eos
+          expect(@request.body).to eq <<-eos
           <Request>
             <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
             <EmailAddress></EmailAddress>
@@ -50,20 +50,20 @@ module Cb
         end
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_application_external
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_application_external)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a correct query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have correct headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a correct body' do
-          @request.body.should == <<-eos
+          expect(@request.body).to eq <<-eos
           <Request>
             <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
             <EmailAddress>email address</EmailAddress>

--- a/spec/cb/requests/category/search_spec.rb
+++ b/spec/cb/requests/category/search_spec.rb
@@ -8,22 +8,22 @@ module Cb
         before(:each) { @request = Cb::Requests::Category::Search.new({}) }
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_job_category_search
-          @request.http_method.should == :get
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_job_category_search)
+          expect(@request.http_method).to eq(:get)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == {
+          expect(@request.query).to eq({
             CountryCode: nil
-          }
+          })
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == nil
+          expect(@request.body).to eq(nil)
         end
       end
 
@@ -35,22 +35,22 @@ module Cb
         end
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_job_category_search
-          @request.http_method.should == :get
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_job_category_search)
+          expect(@request.http_method).to eq(:get)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == {
+          expect(@request.query).to eq({
             CountryCode: "Hello"
-          }
+          })
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == nil
+          expect(@request.body).to eq(nil)
         end
       end
     end

--- a/spec/cb/requests/data_lists/countries_spec.rb
+++ b/spec/cb/requests/data_lists/countries_spec.rb
@@ -24,7 +24,6 @@ module Cb
 
       it { expect(subject.api_uri).to eq '/consumer/datalist/countries'}
       it { expect(token).to receive(:get).with(uri) }
-      it { expect(subject.get).to_not raise_error }
 
       context 'when country code is set' do
         let(:args) { { 'countrycode' => 'GR' } }

--- a/spec/cb/requests/data_lists/countries_spec.rb
+++ b/spec/cb/requests/data_lists/countries_spec.rb
@@ -24,7 +24,7 @@ module Cb
 
       it { expect(subject.api_uri).to eq '/consumer/datalist/countries'}
       it { expect(token).to receive(:get).with(uri) }
-      it { expect(subject.get).to_not raise_error(NotImplementedError) }
+      it { expect(subject.get).to_not raise_error }
 
       context 'when country code is set' do
         let(:args) { { 'countrycode' => 'GR' } }

--- a/spec/cb/requests/data_lists/desired_job_type_spec.rb
+++ b/spec/cb/requests/data_lists/desired_job_type_spec.rb
@@ -23,7 +23,7 @@ module Cb
       end
 
       it { expect(token).to receive(:get).with(uri) }
-      it { expect(subject.get).to_not raise_error(NotImplementedError) }
+      it { expect(subject.get).to_not raise_error }
 
       context 'when countrycode is set' do
         let(:args) { { 'countrycode' => 'GR' } }

--- a/spec/cb/requests/data_lists/desired_job_type_spec.rb
+++ b/spec/cb/requests/data_lists/desired_job_type_spec.rb
@@ -23,7 +23,6 @@ module Cb
       end
 
       it { expect(token).to receive(:get).with(uri) }
-      it { expect(subject.get).to_not raise_error }
 
       context 'when countrycode is set' do
         let(:args) { { 'countrycode' => 'GR' } }

--- a/spec/cb/requests/data_lists/languages_spec.rb
+++ b/spec/cb/requests/data_lists/languages_spec.rb
@@ -24,7 +24,6 @@ module Cb
 
       it { expect(subject.api_uri).to eq '/consumer/datalist/languages'}
       it { expect(token).to receive(:get).with(uri) }
-      it { expect(subject.get).to_not raise_error }
 
       context 'when country code is set' do
         let(:args) { { 'countrycode' => 'GR' } }

--- a/spec/cb/requests/data_lists/languages_spec.rb
+++ b/spec/cb/requests/data_lists/languages_spec.rb
@@ -24,7 +24,7 @@ module Cb
 
       it { expect(subject.api_uri).to eq '/consumer/datalist/languages'}
       it { expect(token).to receive(:get).with(uri) }
-      it { expect(subject.get).to_not raise_error(NotImplementedError) }
+      it { expect(subject.get).to_not raise_error }
 
       context 'when country code is set' do
         let(:args) { { 'countrycode' => 'GR' } }

--- a/spec/cb/requests/resumes/delete_spec.rb
+++ b/spec/cb/requests/resumes/delete_spec.rb
@@ -8,24 +8,24 @@ module Cb
         let(:request) { Cb::Requests::Resumes::Delete.new({}) }
 
         it 'will be correctly configured' do
-          request.endpoint_uri.should == Cb.configuration.uri_resume_delete.sub(':resume_hash', '')
-          request.http_method.should == :delete
+          expect(request.endpoint_uri).to eq(Cb.configuration.uri_resume_delete.sub(':resume_hash', ''))
+          expect(request.http_method).to eq(:delete)
         end
 
         it 'will have a basic query string' do
-          request.query.should eq({ externalUserID: nil })
+          expect(request.query).to eq({ externalUserID: nil })
         end
 
         it 'will have basic headers' do
-          request.headers.should == {
+          expect(request.headers).to eq({
               'DeveloperKey' => Cb.configuration.dev_key,
               'HostSite' => Cb.configuration.host_site,
               'Content-Type' => 'application/json'
-          }
+          })
         end
 
         it 'will have a basic body' do
-          request.body.should == nil
+          expect(request.body).to eq(nil)
         end
       end
 
@@ -34,24 +34,24 @@ module Cb
 
 
         it 'will be correctly configured' do
-          request.endpoint_uri.should == Cb.configuration.uri_resume_get.sub(':resume_hash', 'resumeHash')
-          request.http_method.should == :delete
+          expect(request.endpoint_uri).to eq(Cb.configuration.uri_resume_get.sub(':resume_hash', 'resumeHash'))
+          expect(request.http_method).to eq(:delete)
         end
 
         it 'will have a basic query string' do
-          request.query.should eq ({ externalUserID: 'externalUserId' })
+          expect(request.query).to eq ({ externalUserID: 'externalUserId' })
         end
 
         it 'will have basic headers' do
-          request.headers.should == {
+          expect(request.headers).to eq({
               'DeveloperKey' => Cb.configuration.dev_key,
               'HostSite' => Cb.configuration.host_site,
               'Content-Type' => 'application/json'
-          }
+          })
         end
 
         it 'will have a basic body' do
-          request.body.should == nil
+          expect(request.body).to eq(nil)
         end
       end
     end

--- a/spec/cb/requests/resumes/list_spec.rb
+++ b/spec/cb/requests/resumes/list_spec.rb
@@ -8,20 +8,20 @@ module Cb
         let(:request) { Cb::Requests::Resumes::List.new({}) }
 
         it 'will be correctly configured' do
-          request.endpoint_uri.should == Cb.configuration.uri_resume_list
-          request.http_method.should == :get
+          expect(request.endpoint_uri).to eq(Cb.configuration.uri_resume_list)
+          expect(request.http_method).to eq(:get)
         end
 
         it 'will have a basic query string' do
-          request.query.should eq({ HostSite: Cb.configuration.host_site, OAuthToken: nil })
+          expect(request.query).to eq({ HostSite: Cb.configuration.host_site, OAuthToken: nil })
         end
 
         it 'will have basic headers' do
-          request.headers.should == nil
+          expect(request.headers).to eq(nil)
         end
 
         it 'will have a basic body' do
-          request.body.should == nil
+          expect(request.body).to eq(nil)
         end
       end
 
@@ -29,20 +29,20 @@ module Cb
         let(:request) { Cb::Requests::Resumes::List.new({ oauth_token: 'token' }) }
 
         it 'will be correctly configured' do
-          request.endpoint_uri.should == Cb.configuration.uri_resume_list
-          request.http_method.should == :get
+          expect(request.endpoint_uri).to eq(Cb.configuration.uri_resume_list)
+          expect(request.http_method).to eq(:get)
         end
 
         it 'will have a basic query string' do
-          request.query.should eq ({ HostSite: Cb.configuration.host_site, OAuthToken: 'token' })
+          expect(request.query).to eq ({ HostSite: Cb.configuration.host_site, OAuthToken: 'token' })
         end
 
         it 'will have basic headers' do
-          request.headers.should == nil
+          expect(request.headers).to eq(nil)
         end
 
         it 'will have a basic body' do
-          request.body.should == nil
+          expect(request.body).to eq(nil)
         end
       end
     end

--- a/spec/cb/requests/resumes/put_spec.rb
+++ b/spec/cb/requests/resumes/put_spec.rb
@@ -9,25 +9,26 @@ module Cb
         let (:request) { Cb::Requests::Resumes::Put.new({}) }
 
         it 'should be correctly configured' do
-          request.endpoint_uri.should == Cb.configuration.uri_resume_put.sub(':resume_hash', '')
-          request.http_method.should == :put
+          expect(request.endpoint_uri).to eq(Cb.configuration.uri_resume_put.sub(':resume_hash', ''))
+          expect(request.http_method).to eq(:put)
         end
 
         it 'should have a basic query string' do
-          request.query.should == nil
+          expect(request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          request.headers.should ==
+          expect(request.headers).to eq(
             {
               'DeveloperKey' => Cb.configuration.dev_key,
               'HostSite' => Cb.configuration.host_site,
               'Content-Type' => 'application/json'
             }
+          )
         end
 
         it 'should have a body' do
-          request.body.should_not == nil
+          expect(request.body).not_to eq(nil)
         end
       end
 
@@ -38,21 +39,22 @@ module Cb
         end
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_resume_put.sub(':resume_hash', 'resumeHash')
-          @request.http_method.should == :put
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_resume_put.sub(':resume_hash', 'resumeHash'))
+          expect(@request.http_method).to eq(:put)
         end
 
         it 'should have basic headers' do
-          @request.headers.should ==
+          expect(@request.headers).to eq(
             {
               'DeveloperKey' => Cb.configuration.dev_key,
               'HostSite' => Cb.configuration.host_site,
               'Content-Type' => 'application/json'
             }
+          )
         end
 
         it 'should have a basic body' do
-          @request.body.should == Mocks::Resume.camel_case_resume_hash.to_json
+          expect(@request.body).to eq(Mocks::Resume.camel_case_resume_hash.to_json)
         end
       end
     end

--- a/spec/cb/requests/user/change_password_spec.rb
+++ b/spec/cb/requests/user/change_password_spec.rb
@@ -8,20 +8,20 @@ module Cb
         before(:each) { @request = Cb::Requests::User::ChangePassword.new({}) }
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_user_change_password
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_user_change_password)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == <<-eos
+          expect(@request.body).to eq <<-eos
             <Request>
               <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
               <ExternalID></ExternalID>
@@ -44,20 +44,20 @@ module Cb
         end
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_user_change_password
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_user_change_password)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == <<-eos
+          expect(@request.body).to eq <<-eos
             <Request>
               <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
               <ExternalID>external id</ExternalID>

--- a/spec/cb/requests/user/check_existing_spec.rb
+++ b/spec/cb/requests/user/check_existing_spec.rb
@@ -8,20 +8,20 @@ module Cb
         before(:each) { @request = Cb::Requests::User::CheckExisting.new({}) }
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_user_check_existing
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_user_check_existing)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == <<-eos
+          expect(@request.body).to eq <<-eos
             <Request>
               <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
               <Email></Email>
@@ -41,20 +41,20 @@ module Cb
         end
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_user_check_existing
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_user_check_existing)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == <<-eos
+          expect(@request.body).to eq <<-eos
             <Request>
               <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
               <Email>email</Email>

--- a/spec/cb/requests/user/delete_spec.rb
+++ b/spec/cb/requests/user/delete_spec.rb
@@ -8,20 +8,20 @@ module Cb
         before(:each) { @request = Cb::Requests::User::Delete.new({}) }
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_user_delete
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_user_delete)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == <<-eos
+          expect(@request.body).to eq <<-eos
             <Request>
               <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
               <ExternalID></ExternalID>
@@ -42,20 +42,20 @@ module Cb
         end
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_user_delete
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_user_delete)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == <<-eos
+          expect(@request.body).to eq <<-eos
             <Request>
               <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
               <ExternalID>external id</ExternalID>

--- a/spec/cb/requests/user/retrieve_spec.rb
+++ b/spec/cb/requests/user/retrieve_spec.rb
@@ -8,20 +8,20 @@ module Cb
         before(:each) { @request = Cb::Requests::User::Retrieve.new({}) }
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_user_retrieve
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_user_retrieve)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == <<-eos
+          expect(@request.body).to eq <<-eos
             <Request>
               <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
               <ExternalID></ExternalID>
@@ -40,20 +40,20 @@ module Cb
         end
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_user_retrieve
-          @request.http_method.should == :post
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_user_retrieve)
+          expect(@request.http_method).to eq(:post)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == nil
+          expect(@request.query).to eq(nil)
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == <<-eos
+          expect(@request.body).to eq <<-eos
             <Request>
               <DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
               <ExternalID>external id</ExternalID>

--- a/spec/cb/requests/user/temporary_password_spec.rb
+++ b/spec/cb/requests/user/temporary_password_spec.rb
@@ -8,20 +8,20 @@ module Cb
         before(:each) { @request = Cb::Requests::User::TemporaryPassword.new({}) }
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_user_temp_password
-          @request.http_method.should == :get
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_user_temp_password)
+          expect(@request.http_method).to eq(:get)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == {'ExternalID' => nil}
+          expect(@request.query).to eq({'ExternalID' => nil})
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == nil
+          expect(@request.body).to eq(nil)
         end
       end
 
@@ -33,20 +33,20 @@ module Cb
         end
 
         it 'should be correctly configured' do
-          @request.endpoint_uri.should == Cb.configuration.uri_user_temp_password
-          @request.http_method.should == :get
+          expect(@request.endpoint_uri).to eq(Cb.configuration.uri_user_temp_password)
+          expect(@request.http_method).to eq(:get)
         end
 
         it 'should have a basic query string' do
-          @request.query.should == {'ExternalID' => 'external id'}
+          expect(@request.query).to eq({'ExternalID' => 'external id'})
         end
 
         it 'should have basic headers' do
-          @request.headers.should == nil
+          expect(@request.headers).to eq(nil)
         end
 
         it 'should have a basic body' do
-          @request.body.should == nil
+          expect(@request.body).to eq(nil)
         end
       end
     end

--- a/spec/cb/responses/anonymous_saved_search/create_spec.rb
+++ b/spec/cb/responses/anonymous_saved_search/create_spec.rb
@@ -52,13 +52,13 @@ module Cb
 
     context '#new' do
       it 'returns a response object with a filled in model' do
-        Responses::AnonymousSavedSearch::Create.new(json_hash).class.should eq Responses::AnonymousSavedSearch::Create
+        expect(Responses::AnonymousSavedSearch::Create.new(json_hash).class).to eq Responses::AnonymousSavedSearch::Create
       end
 
       it 'instantiates new model objects' do
         response = Responses::AnonymousSavedSearch::Create.new(json_hash)
 
-        response.model.class.should == Cb::Models::SavedSearch
+        expect(response.model.class).to eq(Cb::Models::SavedSearch)
       end
 
     end

--- a/spec/cb/responses/anonymous_saved_search/delete_spec.rb
+++ b/spec/cb/responses/anonymous_saved_search/delete_spec.rb
@@ -9,13 +9,13 @@ module Cb
 
     context '#new' do
       it 'returns a response object with a filled in model' do
-        Responses::AnonymousSavedSearch::Delete.new(json_hash).class.should eq Responses::AnonymousSavedSearch::Delete
+        expect(Responses::AnonymousSavedSearch::Delete.new(json_hash).class).to eq Responses::AnonymousSavedSearch::Delete
       end
 
       it 'instantiates new model objects' do
         response = Responses::AnonymousSavedSearch::Delete.new(json_hash)
 
-        response.response["Status"].should == 'yay'
+        expect(response.response["Status"]).to eq('yay')
       end
 
     end

--- a/spec/cb/responses/api_response_spec.rb
+++ b/spec/cb/responses/api_response_spec.rb
@@ -82,31 +82,31 @@ module Cb
 
         context '#models' do
           it 'returns whatever is returned from the overriden #extract_models method' do
-            DumbValidResponse.new(valid_input_hash).models.should eq model_hashes
+            expect(DumbValidResponse.new(valid_input_hash).models).to eq model_hashes
           end
         end
 
         # #model exists just in case you want to call a method that makes sense to get only a single model (some APIs return only 1 of something)
         context '#model' do
           it 'returns whatever is returned from the overriden #extract_models method' do
-            DumbValidResponse.new(valid_input_hash).model.should eq model_hashes
+            expect(DumbValidResponse.new(valid_input_hash).model).to eq model_hashes
           end
         end
 
         context '#timing' do
           it 'returns a timing object that responds to #elapsed' do
-            DumbValidResponse.new(valid_input_hash).timing.respond_to?(:elapsed).should eq true
+            expect(DumbValidResponse.new(valid_input_hash).timing.respond_to?(:elapsed)).to eq true
           end
 
           it 'returns a timing object that responds to #response_sent' do
-            DumbValidResponse.new(valid_input_hash).timing.respond_to?(:response_sent).should eq true
+            expect(DumbValidResponse.new(valid_input_hash).timing.respond_to?(:response_sent)).to eq true
           end
         end
 
         context '#errors' do
           # #errors delegates to a different object with its own suite of tests
           it 'returns an errors object' do
-            DumbValidResponse.new(valid_input_hash).respond_to?(:errors).should eq true
+            expect(DumbValidResponse.new(valid_input_hash).respond_to?(:errors)).to eq true
           end
         end
       end
@@ -124,7 +124,7 @@ module Cb
           end
           
           it 'metadata parsing does not occur' do
-            Responses::Metadata.should_not_receive(:new)
+            expect(Responses::Metadata).not_to receive(:new)
             ResponseWithoutMetadataParsing.new(valid_input_hash)
           end
         end

--- a/spec/cb/responses/application_external/submit_application_spec.rb
+++ b/spec/cb/responses/application_external/submit_application_spec.rb
@@ -10,13 +10,13 @@ module Cb
 
     context '#new' do
       it 'returns a response object with a filled in model' do
-        Responses::ApplicationExternal::SubmitApplication.new(json_hash).class.should eq Responses::ApplicationExternal::SubmitApplication
+        expect(Responses::ApplicationExternal::SubmitApplication.new(json_hash).class).to eq Responses::ApplicationExternal::SubmitApplication
       end
 
       it 'instantiates new model objects' do
         response = Responses::ApplicationExternal::SubmitApplication.new(json_hash)
 
-        response.model.apply_url.should == "website.com"
+        expect(response.model.apply_url).to eq("website.com")
       end
 
     end

--- a/spec/cb/responses/category/search_spec.rb
+++ b/spec/cb/responses/category/search_spec.rb
@@ -44,29 +44,29 @@ module Cb
 
     context '#new' do
       it 'returns a response object with a filled in model' do
-        Responses::Category::Search.new(json_hash).class.should eq Responses::Category::Search
+        expect(Responses::Category::Search.new(json_hash).class).to eq Responses::Category::Search
       end
 
       it 'instantiates new model objects' do
         models = Responses::Category::Search.new(json_hash).models
 
-        models.length.should == 4
+        expect(models.length).to eq(4)
 
-        models[0].code.should == 'JN001'
-        models[0].name.should == 'Accounting'
-        models[0].language.should == 'en-US'
+        expect(models[0].code).to eq('JN001')
+        expect(models[0].name).to eq('Accounting')
+        expect(models[0].language).to eq('en-US')
 
-        models[1].code.should == 'JN002'
-        models[1].name.should == 'Admin - Clerical'
-        models[1].language.should == 'en-US'
+        expect(models[1].code).to eq('JN002')
+        expect(models[1].name).to eq('Admin - Clerical')
+        expect(models[1].language).to eq('en-US')
 
-        models[2].code.should == 'JN054'
-        models[2].name.should == 'Automotive'
-        models[2].language.should == 'en-US'
+        expect(models[2].code).to eq('JN054')
+        expect(models[2].name).to eq('Automotive')
+        expect(models[2].language).to eq('en-US')
 
-        models[3].code.should == 'JN038'
-        models[3].name.should == 'Banking'
-        models[3].language.should == 'en-US'
+        expect(models[3].code).to eq('JN038')
+        expect(models[3].name).to eq('Banking')
+        expect(models[3].language).to eq('en-US')
       end
 
     end

--- a/spec/cb/responses/company/find_spec.rb
+++ b/spec/cb/responses/company/find_spec.rb
@@ -67,7 +67,7 @@ module Cb
 
     context '#new' do
       it 'returns a response object with a filled in model' do
-        Responses::Company::Find.new(json_hash).class.should eq Responses::Company::Find
+        expect(Responses::Company::Find.new(json_hash).class).to eq Responses::Company::Find
       end
 
       it 'instantiates new model objects' do

--- a/spec/cb/responses/education/get_spec.rb
+++ b/spec/cb/responses/education/get_spec.rb
@@ -27,27 +27,27 @@ module Cb
 
     context '#new' do
       it 'returns a response object with a filled in model' do
-        Responses::Education::Get.new(json_hash).class.should eq Responses::Education::Get
+        expect(Responses::Education::Get.new(json_hash).class).to eq Responses::Education::Get
       end
 
       it 'instantiates new model objects' do
         models = Responses::Education::Get.new(json_hash).models
 
-        models[0].class.should == Cb::Models::Education
+        expect(models[0].class).to eq(Cb::Models::Education)
 
-        models.length.should == 3
+        expect(models.length).to eq(3)
 
-        models[0].code.should == 'DRNS'
-        models[0].text.should == 'Not Specified'
-        models[0].language.should == 'en-US'
+        expect(models[0].code).to eq('DRNS')
+        expect(models[0].text).to eq('Not Specified')
+        expect(models[0].language).to eq('en-US')
 
-        models[1].code.should == 'DR3210'
-        models[1].text.should == 'None'
-        models[1].language.should == 'en-US'
+        expect(models[1].code).to eq('DR3210')
+        expect(models[1].text).to eq('None')
+        expect(models[1].language).to eq('en-US')
 
-        models[2].code.should == 'DR3211'
-        models[2].text.should == 'High School'
-        models[2].language.should == 'en-US'
+        expect(models[2].code).to eq('DR3211')
+        expect(models[2].text).to eq('High School')
+        expect(models[2].language).to eq('en-US')
       end
 
     end

--- a/spec/cb/responses/email_subscription/response_spec.rb
+++ b/spec/cb/responses/email_subscription/response_spec.rb
@@ -20,7 +20,7 @@ module Cb
 
     context '#new' do
       it 'returns a response object with a filled in model' do
-        Responses::EmailSubscription::Response.new(json_hash).class.should eq Responses::EmailSubscription::Response
+        expect(Responses::EmailSubscription::Response.new(json_hash).class).to eq Responses::EmailSubscription::Response
       end
 
       it 'instantiates new model objects' do

--- a/spec/cb/responses/employee_types/search_spec.rb
+++ b/spec/cb/responses/employee_types/search_spec.rb
@@ -10,17 +10,17 @@ module Cb
     end
 
     before(:each) do
-      Responses::Metadata.stub(:new)
-      Models::EmployeeType.stub(:new)
+      allow(Responses::Metadata).to receive(:new)
+      allow(Models::EmployeeType).to receive(:new)
     end
 
     context '#new' do
       it 'returns an employee types response object' do
-        Responses::EmployeeTypes::Search.new(json_hash).class.should eq Responses::EmployeeTypes::Search
+        expect(Responses::EmployeeTypes::Search.new(json_hash).class).to eq Responses::EmployeeTypes::Search
       end
 
       it 'instantiates new model objects' do
-        Models::EmployeeType.should_receive(:new)
+        expect(Models::EmployeeType).to receive(:new)
         Responses::EmployeeTypes::Search.new(json_hash)
       end
 
@@ -59,7 +59,7 @@ module Cb
       it 'each hash in the array under EmployeeType node makes a model' do
         hash_count = json_hash['ResponseEmployeeTypes']['EmployeeTypes']['EmployeeType'].count
         model_count = Responses::EmployeeTypes::Search.new(json_hash).models.count
-        model_count.should eq hash_count
+        expect(model_count).to eq hash_count
       end
     end
   end

--- a/spec/cb/responses/errors_spec.rb
+++ b/spec/cb/responses/errors_spec.rb
@@ -44,9 +44,9 @@ module Cb
     context '#parsed' do
       it 'returns an enumerable of strings' do
         errors = Responses::Errors.new(@errors_hash, false)
-        errors.parsed.respond_to?(:[])   .should eq true
-        errors.parsed.respond_to?(:count).should eq true
-        errors.parsed.respond_to?(:map)  .should eq true
+        expect(errors.parsed.respond_to?(:[]))   .to eq true
+        expect(errors.parsed.respond_to?(:count)).to eq true
+        expect(errors.parsed.respond_to?(:map))  .to eq true
       end
     end
 

--- a/spec/cb/responses/industry/search_spec.rb
+++ b/spec/cb/responses/industry/search_spec.rb
@@ -10,8 +10,8 @@ module Cb
     end
 
     before(:each) do
-      Responses::Metadata.stub(:new)
-      Models::Industry.stub(:new)
+      allow(Responses::Metadata).to receive(:new)
+      allow(Models::Industry).to receive(:new)
     end
 
     context '#new' do
@@ -20,7 +20,7 @@ module Cb
       end
 
       it 'instantiates new model objects' do
-        Models::Industry.should_receive(:new)
+        expect(Models::Industry).to receive(:new)
         Responses::Industry::Search.new(response)
       end
 

--- a/spec/cb/responses/metadata_spec.rb
+++ b/spec/cb/responses/metadata_spec.rb
@@ -6,11 +6,11 @@ module Cb
 
       context 'when passed valid input' do
         it 'sets #errors' do
-          Responses::Metadata.new(valid_input).errors.nil?.should eq false
+          expect(Responses::Metadata.new(valid_input).errors.nil?).to eq false
         end
 
         it 'sets #timing' do
-          Responses::Metadata.new(valid_input).timing.nil?.should eq false
+          expect(Responses::Metadata.new(valid_input).timing.nil?).to eq false
         end
       end
     end

--- a/spec/cb/responses/timing_spec.rb
+++ b/spec/cb/responses/timing_spec.rb
@@ -38,13 +38,13 @@ module Cb
       context 'when initialized with a valid input hash' do
         it 'contains a DateTime extracted from the string input date' do
           target = valid_input_hash['TimeResponseSent']
-          valid_instance.response_sent.should eq DateTime.parse(target)
+          expect(valid_instance.response_sent).to eq DateTime.parse(target)
         end
       end
 
       context 'when the input hash is lacking the field' do
         it 'contains nil' do
-          Responses::Timing.new({}).response_sent.should eq nil
+          expect(Responses::Timing.new({}).response_sent).to eq nil
         end
       end
     end
@@ -53,13 +53,13 @@ module Cb
       context 'when initialized with a valid input hash' do
         it 'contains a float extracted from the string input float' do
           target = valid_input_hash['TimeElapsed']
-          valid_instance.elapsed.should eq target.to_f
+          expect(valid_instance.elapsed).to eq target.to_f
         end
       end
 
       context 'when the input hash is lacking the field' do
         it 'contains nil' do
-          Responses::Timing.new({}).elapsed.should eq nil
+          expect(Responses::Timing.new({}).elapsed).to eq nil
         end
       end
     end

--- a/spec/cb/responses/user/change_password_spec.rb
+++ b/spec/cb/responses/user/change_password_spec.rb
@@ -14,7 +14,7 @@ module Cb
 
     context '#new' do
       it 'returns a temp password response object' do
-        Responses::User::ChangePassword.new(json_hash).should
+        expect(Responses::User::ChangePassword.new(json_hash)).to
         be_an_instance_of Responses::User::ChangePassword
       end
 

--- a/spec/cb/responses/user/change_password_spec.rb
+++ b/spec/cb/responses/user/change_password_spec.rb
@@ -14,8 +14,7 @@ module Cb
 
     context '#new' do
       it 'returns a temp password response object' do
-        expect(Responses::User::ChangePassword.new(json_hash)).to
-        be_an_instance_of Responses::User::ChangePassword
+        expect(Responses::User::ChangePassword.new(json_hash)).to be_an_instance_of Responses::User::ChangePassword
       end
 
       context 'when input response hash cannot be validated due to' do

--- a/spec/cb/responses/user/check_existing_spec.rb
+++ b/spec/cb/responses/user/check_existing_spec.rb
@@ -20,8 +20,7 @@ module Cb
 
     context '#new' do
       it 'returns a temp password response object' do
-        expect(Responses::User::CheckExisting.new(json_hash)).to
-        be_an_instance_of Responses::User::CheckExisting
+        expect(Responses::User::CheckExisting.new(json_hash)).to be_an_instance_of Responses::User::CheckExisting
       end
 
       context 'when input response hash cannot be validated due to' do

--- a/spec/cb/responses/user/check_existing_spec.rb
+++ b/spec/cb/responses/user/check_existing_spec.rb
@@ -20,7 +20,7 @@ module Cb
 
     context '#new' do
       it 'returns a temp password response object' do
-        Responses::User::CheckExisting.new(json_hash).should
+        expect(Responses::User::CheckExisting.new(json_hash)).to
         be_an_instance_of Responses::User::CheckExisting
       end
 

--- a/spec/cb/responses/user/delete_spec.rb
+++ b/spec/cb/responses/user/delete_spec.rb
@@ -14,8 +14,7 @@ module Cb
 
     context '#new' do
       it 'returns a temp password response object' do
-        expect(Responses::User::Delete.new(json_hash)).to
-        be_an_instance_of Responses::User::Delete
+        expect(Responses::User::Delete.new(json_hash)).to be_an_instance_of Responses::User::Delete
       end
 
       context 'when input response hash cannot be validated due to' do

--- a/spec/cb/responses/user/delete_spec.rb
+++ b/spec/cb/responses/user/delete_spec.rb
@@ -14,7 +14,7 @@ module Cb
 
     context '#new' do
       it 'returns a temp password response object' do
-        Responses::User::Delete.new(json_hash).should
+        expect(Responses::User::Delete.new(json_hash)).to
         be_an_instance_of Responses::User::Delete
       end
 

--- a/spec/cb/responses/user/retrieve_spec.rb
+++ b/spec/cb/responses/user/retrieve_spec.rb
@@ -13,7 +13,7 @@ module Cb
 
     context '#new' do
       it 'returns a temp password response object' do
-        Responses::User::Retrieve.new(json_hash).should
+        expect(Responses::User::Retrieve.new(json_hash)).to
         be_an_instance_of Responses::User::Retrieve
       end
 
@@ -32,7 +32,7 @@ module Cb
     context '#models' do
       it 'returns the TemporaryPassword node from the response' do
         response = Responses::User::Retrieve.new(json_hash)
-        response.model.should be_an_instance_of Cb::Models::User
+        expect(response.model).to be_an_instance_of Cb::Models::User
       end
     end
   end

--- a/spec/cb/responses/user/retrieve_spec.rb
+++ b/spec/cb/responses/user/retrieve_spec.rb
@@ -13,8 +13,7 @@ module Cb
 
     context '#new' do
       it 'returns a temp password response object' do
-        expect(Responses::User::Retrieve.new(json_hash)).to
-        be_an_instance_of Responses::User::Retrieve
+        expect(Responses::User::Retrieve.new(json_hash)).to be_an_instance_of Responses::User::Retrieve
       end
 
       context 'when input response hash cannot be validated due to' do

--- a/spec/cb/responses/user/temporary_password_spec.rb
+++ b/spec/cb/responses/user/temporary_password_spec.rb
@@ -11,7 +11,7 @@ module Cb
 
     context '#new' do
       it 'returns a temp password response object' do
-        Responses::User::TemporaryPassword.new(json_hash).should
+        expect(Responses::User::TemporaryPassword.new(json_hash)).to
           be_an_instance_of Responses::User::TemporaryPassword
       end
 

--- a/spec/cb/responses/user/temporary_password_spec.rb
+++ b/spec/cb/responses/user/temporary_password_spec.rb
@@ -11,8 +11,8 @@ module Cb
 
     context '#new' do
       it 'returns a temp password response object' do
-        expect(Responses::User::TemporaryPassword.new(json_hash)).to
-          be_an_instance_of Responses::User::TemporaryPassword
+        expect(Responses::User::TemporaryPassword.new(json_hash)).
+          to be_an_instance_of Responses::User::TemporaryPassword
       end
 
       context 'when input response hash cannot be validated due to' do

--- a/spec/cb/utils/api_spec.rb
+++ b/spec/cb/utils/api_spec.rb
@@ -14,11 +14,11 @@ module Cb
 
         context 'when we have observers' do
           before{
-            Cb.configuration.stub(:observers).and_return(Array(Mocks::Observer))
+            allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
            }
           it 'returns an instance of Api with the observers attached' do
-            Mocks::Observer.should_receive(:new)
-            Cb::Utils::Api.any_instance.should_receive(:add_observer)
+            expect(Mocks::Observer).to receive(:new)
+            expect_any_instance_of(Cb::Utils::Api).to receive(:add_observer)
             expect(Cb::Utils::Api.instance).to be_a_kind_of(Cb::Utils::Api)
           end
         end
@@ -28,24 +28,24 @@ module Cb
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
           before{
-            Cb.configuration.stub(:observers).and_return(Array(Mocks::Observer))
-            Api.stub(:get).with(path, options).and_return(response)
+            allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
+            allow(Api).to receive(:get).with(path, options).and_return(response)
           }
           it 'will notify the observers' do
-            api.should_receive(:notify_observers).twice.and_call_original
-            Mocks::Observer.any_instance.should_receive(:update).at_most(2).times
+            expect(api).to receive(:notify_observers).twice.and_call_original
+            expect_any_instance_of(Mocks::Observer).to receive(:update).at_most(2).times
             api.cb_get(path)
           end
         end
         it 'sends #post to HttParty' do
-          Api.should_receive(:get).with(path, options)
+          expect(Api).to receive(:get).with(path, options)
           api.cb_get(path)
         end
 
         context 'When Cb base_uri is configured' do
           before {
             Cb.configuration.base_uri = 'http://www.applecat.com'
-            Api.stub(:get).with(path, options)
+            allow(Api).to receive(:get).with(path, options)
           }
 
           it 'sets base_uri on Api' do
@@ -57,11 +57,11 @@ module Cb
         context 'When a response is returned' do
           let(:response) { { success: 'yeah' } }
           before {
-            Api.stub(:get).with(path, options).and_return(response)
+            allow(Api).to receive(:get).with(path, options).and_return(response)
           }
 
           it 'sends #validate to ResponseValidator with the response' do
-            ResponseValidator.should_receive(:validate).with(response).and_return(response)
+            expect(ResponseValidator).to receive(:validate).with(response).and_return(response)
             api.cb_get(path)
           end
         end
@@ -72,24 +72,24 @@ module Cb
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
           before{
-            Cb.configuration.stub(:observers).and_return(Array(Mocks::Observer))
-            Api.stub(:post).with(path, options).and_return(response)
+            allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
+            allow(Api).to receive(:post).with(path, options).and_return(response)
           }
           it 'will notify the observers' do
-            api.should_receive(:notify_observers).twice.and_call_original
-            Mocks::Observer.any_instance.should_receive(:update).at_most(2).times
+            expect(api).to receive(:notify_observers).twice.and_call_original
+            expect_any_instance_of(Mocks::Observer).to receive(:update).at_most(2).times
             api.cb_post(path)
           end
         end
         it 'sends #post to HttParty' do
-          Api.should_receive(:post).with(path, options)
+          expect(Api).to receive(:post).with(path, options)
           api.cb_post(path)
         end
 
         context 'When Cb base_uri is configured' do
           before {
             Cb.configuration.base_uri = 'http://www.bananadog.org'
-            Api.stub(:post).with(path, options)
+            allow(Api).to receive(:post).with(path, options)
           }
 
           it 'sets base_uri on Api' do
@@ -101,11 +101,11 @@ module Cb
         context 'When a response is returned' do
           let(:response) { { success: 'yeah' } }
           before {
-            Api.stub(:post).with(path, options).and_return(response)
+            allow(Api).to receive(:post).with(path, options).and_return(response)
           }
 
           it 'sends #validate to ResponseValidator with the response' do
-            ResponseValidator.should_receive(:validate).with(response).and_return(response)
+            expect(ResponseValidator).to receive(:validate).with(response).and_return(response)
             api.cb_post(path)
           end
         end
@@ -116,24 +116,24 @@ module Cb
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
           before{
-            Cb.configuration.stub(:observers).and_return(Array(Mocks::Observer))
-            Api.stub(:put).with(path, options).and_return(response)
+            allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
+            allow(Api).to receive(:put).with(path, options).and_return(response)
           }
           it 'will notify the observers' do
-            api.should_receive(:notify_observers).twice.and_call_original
-            Mocks::Observer.any_instance.should_receive(:update).at_most(2).times
+            expect(api).to receive(:notify_observers).twice.and_call_original
+            expect_any_instance_of(Mocks::Observer).to receive(:update).at_most(2).times
             api.cb_put(path)
           end
         end
         it 'sends #put to HttParty' do
-          Api.should_receive(:put).with(path, options)
+          expect(Api).to receive(:put).with(path, options)
           api.cb_put(path)
         end
 
         context 'When Cb base_uri is configured' do
           before {
             Cb.configuration.base_uri = 'http://www.kylerox.org'
-            Api.stub(:put).with(path, options)
+            allow(Api).to receive(:put).with(path, options)
           }
 
           it 'sets base_uri on Api' do
@@ -146,11 +146,11 @@ module Cb
         context 'When a response is returned' do
           let(:response) { { success: 'yeah' } }
           before {
-            Api.stub(:put).with(path, options).and_return(response)
+            allow(Api).to receive(:put).with(path, options).and_return(response)
           }
 
           it 'sends #validate to ResponseValidator with the response' do
-            ResponseValidator.should_receive(:validate).with(response).and_return(response)
+            expect(ResponseValidator).to receive(:validate).with(response).and_return(response)
             api.cb_put(path)
           end
         end
@@ -161,24 +161,24 @@ module Cb
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
           before{
-            Cb.configuration.stub(:observers).and_return(Array(Mocks::Observer))
-            Api.stub(:delete).with(path, options).and_return(response)
+            allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
+            allow(Api).to receive(:delete).with(path, options).and_return(response)
           }
           it 'will notify the observers' do
-            api.should_receive(:notify_observers).twice.and_call_original
-            Mocks::Observer.any_instance.should_receive(:update).at_most(2).times
+            expect(api).to receive(:notify_observers).twice.and_call_original
+            expect_any_instance_of(Mocks::Observer).to receive(:update).at_most(2).times
             api.cb_delete(path)
           end
         end
         it 'sends #delete to HttParty' do
-          Api.should_receive(:delete).with(path, options)
+          expect(Api).to receive(:delete).with(path, options)
           api.cb_delete(path)
         end
 
         context 'When Cb base_uri is configured' do
           before {
             Cb.configuration.base_uri = 'http://www.kylerox.org'
-            Api.stub(:delete).with(path, options)
+            allow(Api).to receive(:delete).with(path, options)
           }
 
           it 'sets base_uri on Api' do
@@ -191,11 +191,11 @@ module Cb
         context 'When a response is returned' do
           let(:response) { { success: 'yeah' } }
           before {
-            Api.stub(:delete).with(path, options).and_return(response)
+            allow(Api).to receive(:delete).with(path, options).and_return(response)
           }
 
           it 'sends #validate to ResponseValidator with the response' do
-            ResponseValidator.should_receive(:validate).with(response).and_return(response)
+            expect(ResponseValidator).to receive(:validate).with(response).and_return(response)
             api.cb_delete(path)
           end
         end
@@ -207,24 +207,24 @@ module Cb
           context 'when we have observers' do
             let(:response) { { success: 'yeah' } }
             before{
-              Cb.configuration.stub(:observers).and_return(Array(Mocks::Observer))
-              Api.stub(:delete).with(path, options).and_return(response)
+              allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
+              allow(Api).to receive(:delete).with(path, options).and_return(response)
             }
             it 'will notify the observers' do
-              api.should_receive(:notify_observers).twice.and_call_original
-              Mocks::Observer.any_instance.should_receive(:update).at_most(2).times
+              expect(api).to receive(:notify_observers).twice.and_call_original
+              expect_any_instance_of(Mocks::Observer).to receive(:update).at_most(2).times
               api.execute_http_request(:delete, nil, path)
             end
           end
           it 'sends #delete to HttParty' do
-            Api.should_receive(:delete).with(path, options)
+            expect(Api).to receive(:delete).with(path, options)
             api.execute_http_request(:delete, nil, path)
           end
 
           context 'When Cb base_uri is configured' do
             before {
               Cb.configuration.base_uri = 'http://www.kylerox.org'
-              Api.stub(:delete).with(path, options)
+              allow(Api).to receive(:delete).with(path, options)
             }
 
             it 'sets base_uri on Api' do
@@ -237,11 +237,11 @@ module Cb
           context 'When a response is returned' do
             let(:response) { { success: 'yeah' } }
             before {
-              Api.stub(:delete).with(path, options).and_return(response)
+              allow(Api).to receive(:delete).with(path, options).and_return(response)
             }
 
             it 'sends #validate to ResponseValidator with the response' do
-              ResponseValidator.should_receive(:validate).with(response).and_return(response)
+              expect(ResponseValidator).to receive(:validate).with(response).and_return(response)
               api.execute_http_request(:delete, nil, path)
             end
           end
@@ -253,7 +253,7 @@ module Cb
         let(:default_uri) { 'http://www.kylerox.org' }
         before {
           Cb.configuration.base_uri = default_uri
-          Api.stub(:delete).with(path, options)
+          allow(Api).to receive(:delete).with(path, options)
         }
 
         context 'passes a base uri' do

--- a/spec/cb/utils/response_array_extractor_spec.rb
+++ b/spec/cb/utils/response_array_extractor_spec.rb
@@ -13,9 +13,9 @@ module Cb
 
         it 'an array with the single item should be returned' do
           animals = Cb::Utils::ResponseArrayExtractor.extract(response_hash, 'Animals')
-          animals.class.should == Array
-          animals.count.should == 1
-          animals[0].should == 'Moose'
+          expect(animals.class).to eq(Array)
+          expect(animals.count).to eq(1)
+          expect(animals[0]).to eq('Moose')
         end
       end
 
@@ -28,10 +28,10 @@ module Cb
 
         it 'an array with multiple items should be returned' do
           animals = Cb::Utils::ResponseArrayExtractor.extract(response_hash, 'Animals')
-          animals.class.should == Array
-          animals.count.should == 2
-          animals[0].should == 'Moose'
-          animals[1].should == 'Kitty'
+          expect(animals.class).to eq(Array)
+          expect(animals.count).to eq(2)
+          expect(animals[0]).to eq('Moose')
+          expect(animals[1]).to eq('Kitty')
         end 
       end
 
@@ -46,10 +46,10 @@ module Cb
 
         it 'is still able to parse' do
           matches = ResponseArrayExtractor.extract(response_hash, 'Matches', 'Match')
-          matches.class.should == Array
-          matches.count.should == 2
-          matches[0].should == 'FUN!'
-          matches[1].should == 'Excite!'
+          expect(matches.class).to eq(Array)
+          expect(matches.count).to eq(2)
+          expect(matches[0]).to eq('FUN!')
+          expect(matches[1]).to eq('Excite!')
         end
       end
 
@@ -59,9 +59,9 @@ module Cb
         }}
         it 'an array of a single item should be returned' do
           test = Cb::Utils::ResponseArrayExtractor.extract(response_hash, 'Hello')
-          test.class.should == Array
-          test.count.should == 1
-          test[0].should == 'world'
+          expect(test.class).to eq(Array)
+          expect(test.count).to eq(1)
+          expect(test[0]).to eq('world')
         end
       end
 
@@ -71,12 +71,12 @@ module Cb
         }}
         it 'an array of items should be returned' do
           test = Cb::Utils::ResponseArrayExtractor.extract(response_hash, 'Hello')
-          test.class.should == Array
-          test.count.should == 4
-          test[0].should == 'world'
-          test[1].should == 'this'
-          test[2].should == 'is'
-          test[3].should == 'awesome'
+          expect(test.class).to eq(Array)
+          expect(test.count).to eq(4)
+          expect(test[0]).to eq('world')
+          expect(test[1]).to eq('this')
+          expect(test[2]).to eq('is')
+          expect(test[3]).to eq('awesome')
         end
       end
 
@@ -86,9 +86,9 @@ module Cb
         }
         it 'an array of items should be returned' do
           test = Cb::Utils::ResponseArrayExtractor.extract(response_hash, 'Hello')
-          test.class.should == Array
-          test.count.should == 0
-          test.should == []
+          expect(test.class).to eq(Array)
+          expect(test.count).to eq(0)
+          expect(test).to eq([])
         end
       end
 

--- a/spec/cb/utils/validator_spec.rb
+++ b/spec/cb/utils/validator_spec.rb
@@ -54,7 +54,7 @@ module Cb
     end
 
     it 'should raise an UnauthorizedError when status code is 401' do
-      response.stub(:code).and_return(401)
+      allow(response).to receive(:code).and_return(401)
       expect{ ResponseValidator.validate(response) }.to raise_error(Cb::UnauthorizedError)
     end
 

--- a/spec/cb/utils/validator_spec.rb
+++ b/spec/cb/utils/validator_spec.rb
@@ -7,56 +7,56 @@ module Cb
     let(:response_property) { double('HTTParty::Response.response') }
 
     before :each do
-      response.stub(:response).and_return(response_property)
-      response.stub(:code).and_return(200)
+      allow(response).to receive(:response).and_return(response_property)
+      allow(response).to receive(:code).and_return(200)
     end
 
     it 'should return empty hash when body is empty' do
-       response.response.stub(:body).and_return(String.new)
+       allow(response.response).to receive(:body).and_return(String.new)
        validation = ResponseValidator.validate(response)
-       validation.empty?.should be_true
+       expect(validation.empty?).to be_truthy
     end
 
     it 'should return empty hash when body is improper json/xml' do
-      response.response.stub(:body).and_return('json')
+      allow(response.response).to receive(:body).and_return('json')
       validation = ResponseValidator.validate(response)
-      validation.empty?.should be_true
+      expect(validation.empty?).to be_truthy
     end
 
     it 'should return empty hash when response is nil' do
       response = nil
       validation = ResponseValidator.validate(response)
-      validation.empty?.should be_true
+      expect(validation.empty?).to be_truthy
     end
 
     it 'should return empty hash when url is invalid' do
-      response.stub(:code).and_return 404
-      response.response.stub(:body).and_return('<!DOCTYPE html></html>')
+      allow(response).to receive(:code).and_return 404
+      allow(response.response).to receive(:body).and_return('<!DOCTYPE html></html>')
       validation = ResponseValidator.validate(response)
-      validation.empty?.should be_true
+      expect(validation.empty?).to be_truthy
     end
 
     it 'should return a full json hash when response status is not 200 and content is json' do
-      response.response.stub(:body).and_return('{"TestJson":{"Test":"True"}}')
+      allow(response.response).to receive(:body).and_return('{"TestJson":{"Test":"True"}}')
       validation = ResponseValidator.validate(response)
-      validation.empty?.should be_false
+      expect(validation.empty?).to be_falsey
     end
 
     it 'should return a blank json hash when status is not 200 and content is html' do
-      response.response.stub(:body).and_return('<!DOCTYPE html></html>')
+      allow(response.response).to receive(:body).and_return('<!DOCTYPE html></html>')
       validation = ResponseValidator.validate(response)
-      validation.empty?.should be_true
+      expect(validation.empty?).to be_truthy
     end
 
     it 'should raise a ServiceUnavailableError when status code is 503' do
-      response.stub(:code).and_return 503
+      allow(response).to receive(:code).and_return 503
       expect{ ResponseValidator.validate(response) }.to raise_error(Cb::ServiceUnavailableError)
     end
 
     context 'when there are JSON parsing errors' do
       context 'and the content payload is not XML' do
         it 'returns an empty hash' do
-          response.response.stub(:body).and_return('yay not json')
+          allow(response.response).to receive(:body).and_return('yay not json')
           validation = ResponseValidator.validate(response)
           expect(validation).to eq Hash.new
         end
@@ -65,7 +65,7 @@ module Cb
       context 'and the content payload is XML' do
         it 'returns the XML hashified' do
           xml = '<yo><this><isxml>yay</isxml></this></yo>'
-          response.response.stub(:body).and_return(xml)
+          allow(response.response).to receive(:body).and_return(xml)
           validation = ResponseValidator.validate(response)
           expect(validation).to be_an_instance_of Hash
           expect(validation).to eq({"yo"=>{"this"=>{"isxml"=>"yay"}}})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,13 +17,6 @@ WebMock.disable_net_connect!
 
 RSpec.configure do |c|
   c.mock_with :rspec do |mocks|
-    # In RSpec 3, `any_instance` implementation blocks will be yielded the receiving
-    # instance as the first block argument to allow the implementation block to use
-    # the state of the receiver.
-    # In RSpec 2.99, to maintain compatibility with RSpec 3 you need to either set
-    # this config option to `false` OR set this to `true` and update your
-    # `any_instance` implementation blocks to account for the first block argument
-    # being the receiving instance.
     mocks.yield_receiver_to_any_instance_implementation_blocks = true
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,8 +16,6 @@ require 'pry'
 WebMock.disable_net_connect!
 
 RSpec.configure do |c|
-  c.treat_symbols_as_metadata_keys_with_true_values = true
-
   c.mock_with :rspec do |mocks|
     # In RSpec 3, `any_instance` implementation blocks will be yielded the receiving
     # instance as the first block argument to allow the implementation block to use

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,17 @@ WebMock.disable_net_connect!
 
 RSpec.configure do |c|
   c.treat_symbols_as_metadata_keys_with_true_values = true
+
+  c.mock_with :rspec do |mocks|
+    # In RSpec 3, `any_instance` implementation blocks will be yielded the receiving
+    # instance as the first block argument to allow the implementation block to use
+    # the state of the receiver.
+    # In RSpec 2.99, to maintain compatibility with RSpec 3 you need to either set
+    # this config option to `false` OR set this to `true` and update your
+    # `any_instance` implementation blocks to account for the first block argument
+    # being the receiving instance.
+    mocks.yield_receiver_to_any_instance_implementation_blocks = true
+  end
 end
 
 require 'support/convenience'


### PR DESCRIPTION
- moves us to RSpec 3.x
- moves us to rspec-pride 3.x
- ZERO deprecation warnings
- ZERO generic warnings (we had some "`and_raise` called with a non-proc object" warnings)
- fixed some specs that were previously not working correctly (user + application client specs)
- everything moved from `should` and `stub` syntax to the updated syntax (`expect` and `allow`)
- Transpec did most of the syntax changes for me! https://github.com/yujinakayama/transpec

:metal:

p.s. please don't let the 70 files changed scare you away, pull this down and run the tests. It'll feel good :)