### PR TITLE
Error response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
-* 16.2.3 changed api error response to use join instead of to_s
+* 16.3.0 changed api error response to use join instead of to_s
 * 16.2.2 change degree code to be degree which fixes compatibilty problems
 * 16.2.1 fix major or program in resume put. it was looking for the wrong value
 * 16.2.0 Added support for work experience ID in resume put

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Version History
 ====
     * All Version bumps are required to update this file as well!!
 ----
+
+* 17.0.0 changed api error response to use join instead of to_s
 * 16.2.2 change degree code to be degree which fixes compatibilty problems
 * 16.2.1 fix major or program in resume put. it was looking for the wrong value
 * 16.2.0 Added support for work experience ID in resume put

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
-* 17.0.0 changed api error response to use join instead of to_s
+* 16.2.3 changed api error response to use join instead of to_s
 * 16.2.2 change degree code to be degree which fixes compatibilty problems
 * 16.2.1 fix major or program in resume put. it was looking for the wrong value
 * 16.2.0 Added support for work experience ID in resume put

--- a/lib/cb/responses/errors.rb
+++ b/lib/cb/responses/errors.rb
@@ -16,7 +16,7 @@ module Cb
       def parsed_errors
         return Array.new unless response.respond_to?(:map)
         errors = response.map { |key, value| parsed_error(key, value) }.flatten
-        raise ApiResponseError.new(errors.to_s) if errors.any? && should_raise
+        raise ApiResponseError.new(errors.join(',')) if errors.any? && should_raise
         errors
       end
 

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '16.2.2'
+  VERSION = '17.0.0'
 end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '16.2.3'
+  VERSION = '16.3.0'
 end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '17.0.0'
+  VERSION = '16.2.3'
 end

--- a/spec/cb/responses/errors_spec.rb
+++ b/spec/cb/responses/errors_spec.rb
@@ -4,6 +4,8 @@ module Cb
 
     context '#new' do
 
+      let(:parsed_error_response) { 'much awesome,so api,wow' }
+
       def self.run_specs
         context 'and the optional boolean arg is omitted' do
           it 'raises an api error since an error was found' do
@@ -25,6 +27,10 @@ module Cb
               Responses::Errors.new(@errors_hash, true)
             end.to raise_error ApiResponseError
           end
+        end
+
+        it 'assigns correct value to @parse' do
+          expect(Responses::Errors.new(@errors_hash, false).parsed).eql? parsed_error_response
         end
       end
 


### PR DESCRIPTION
I want to propose a change to the @parsed variable. Currently if there is an api response error we create the message using the to_s method on the hash/array. 

This returns an ugly string i.e. "[\"File upload data is larger than the maximum of 1024KB.\"]"

I changed it to join(',')  which will now return 'File upload data is larger than the maximum of 1024KB.'

If there is an array such as [much, awesome, so api, wow]
it will now return  'much awesome,so api,wow'

we are currently doing some message conversion and translation and instead of regexing this in our app I thought it would be more elegant to do this in the error class. Thoughts?