### PR TITLE
Add jobsearch v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
-* 18.0.0 Adding job search version 3 as additional call
+* 17.1.0 Adding job search version 3 as additional call
 * 17.0.2 making sure we explicitly ask for version 1 of the consumer APIs
 * 17.0.1 adding posted_time and company_did to job results
 * 17.0.0 removed spot cms dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
+* 18.0.0 Adding job search version 3 as additional call
 * 17.0.1 adding posted_time and company_did to job results
 * 17.0.0 removed spot cms dependency
 * 16.3.0 changed api error response to use join instead of to_s

--- a/lib/cb/clients/job.rb
+++ b/lib/cb/clients/job.rb
@@ -9,11 +9,6 @@ module Cb
           response = api_client.cb_get(Cb.configuration.uri_job_search, query: args)
           Cb::Responses::Job::Search.new(response)
         end
-        
-        def search_v3(args)
-          response = api_client.cb_get(Cb.configuration.uri_job_search_v3, query: args)
-          Cb::Responses::Job::SearchV3.new(response)
-        end
 
         def find_by_criteria(criteria)
           query = api_client.class.criteria_to_hash(criteria)

--- a/lib/cb/clients/job.rb
+++ b/lib/cb/clients/job.rb
@@ -9,6 +9,11 @@ module Cb
           response = api_client.cb_get(Cb.configuration.uri_job_search, query: args)
           Cb::Responses::Job::Search.new(response)
         end
+        
+        def search_v3(args)
+          response = api_client.cb_get(Cb.configuration.uri_job_search_v3, query: args)
+          Cb::Responses::Job::SearchV3.new(response)
+        end
 
         def find_by_criteria(criteria)
           query = api_client.class.criteria_to_hash(criteria)

--- a/lib/cb/config.rb
+++ b/lib/cb/config.rb
@@ -47,7 +47,7 @@ module Cb
       @uri_employee_types                 ||= '/v1/employeetypes'
       @uri_company_find                   ||= '/Employer/CompanyDetails'
       @uri_job_search                     ||= '/v1/JobSearch'
-      @uri_job_search_v3                  ||= '/jobsearch/jobs'
+      @uri_job_search_v3                  ||= '/consumer/jobs/search/'
       @uri_job_find                       ||= '/v3/Job'
       @uri_education_code                 ||= '/v1/EducationCodes'
       @uri_recommendation_for_job         ||= '/v1/Recommendations/ForJob'

--- a/lib/cb/config.rb
+++ b/lib/cb/config.rb
@@ -47,6 +47,7 @@ module Cb
       @uri_employee_types                 ||= '/v1/employeetypes'
       @uri_company_find                   ||= '/Employer/CompanyDetails'
       @uri_job_search                     ||= '/v1/JobSearch'
+      @uri_job_search_v3                  ||= '/jobsearch/jobs'
       @uri_job_find                       ||= '/v3/Job'
       @uri_education_code                 ||= '/v1/EducationCodes'
       @uri_recommendation_for_job         ||= '/v1/Recommendations/ForJob'

--- a/lib/cb/models/implementations/job_results_v3.rb
+++ b/lib/cb/models/implementations/job_results_v3.rb
@@ -2,9 +2,11 @@ module Cb
   module Models
     class JobResultsV3
       attr_reader :api_response
+      attr_reader :response_metadata
       
       def initialize(response_hash = {})
-        @api_response = response_hash
+        @api_response = response_hash['data']
+        @response_metadata = response_hash['search_metadata']
       end
     end
   end

--- a/lib/cb/models/implementations/job_results_v3.rb
+++ b/lib/cb/models/implementations/job_results_v3.rb
@@ -2,11 +2,9 @@ module Cb
   module Models
     class JobResultsV3
       attr_reader :api_response
-      attr_reader :response_metadata
       
       def initialize(response_hash = {})
-        @api_response = response_hash['data']
-        @response_metadata = response_hash['search_metadata']
+        @api_response = response_hash
       end
     end
   end

--- a/lib/cb/models/implementations/job_results_v3.rb
+++ b/lib/cb/models/implementations/job_results_v3.rb
@@ -1,0 +1,11 @@
+module Cb
+  module Models
+    class JobResultsV3
+      attr_reader :api_response
+      
+      def initialize(response_hash = {})
+        @api_response = response_hash
+      end
+    end
+  end
+end

--- a/lib/cb/requests/job_search/get.rb
+++ b/lib/cb/requests/job_search/get.rb
@@ -1,0 +1,24 @@
+module  Cb
+  module Requests
+    module JobSearch
+      class Get < Base
+        
+        def endpoint_uri
+          Cb.configuration.uri_job_search_v3
+        end
+        
+        def http_method
+          :get
+        end
+        
+        def headers
+          {
+            'Authorization' => args[:three_scale_token] == nil ? '' : "Bearer #{args[:three_scale_token]}",
+            'HostSite' => args[:host_site] || Cb.configuration.host_site,
+            'Accept' => 'version=v3'
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/cb/requests/job_search/get.rb
+++ b/lib/cb/requests/job_search/get.rb
@@ -13,7 +13,7 @@ module  Cb
         
         def headers
           {
-            'Authorization' => args[:three_scale_token] == nil ? '' : "Bearer #{args[:three_scale_token]}",
+            'Authorization' => args[:three_scale_token].nil? ? '' : "Bearer #{args[:three_scale_token]}",
             'HostSite' => args[:host_site] || Cb.configuration.host_site,
             'Accept' => 'applicatin/json;version=3.0'
           }

--- a/lib/cb/requests/job_search/get.rb
+++ b/lib/cb/requests/job_search/get.rb
@@ -15,7 +15,7 @@ module  Cb
           {
             'Authorization' => args[:three_scale_token] == nil ? '' : "Bearer #{args[:three_scale_token]}",
             'HostSite' => args[:host_site] || Cb.configuration.host_site,
-            'Accept' => 'applicatin/json;version=v3'
+            'Accept' => 'applicatin/json;version=3.0'
           }
         end
       end

--- a/lib/cb/responses/job/search_v3.rb
+++ b/lib/cb/responses/job/search_v3.rb
@@ -10,17 +10,17 @@ module Cb
         end
 
         def hash_containing_metadata
-          'ResponseJobSearch'
+          'search_metadata'
         end
 
         def extract_models
-          Models::JobResultsV3.new(response[root_node])
+          Models::JobResultsV3.new(response)
         end
 
         private
 
         def root_node
-          'ResponseJobSearch'
+          'data'
         end
       end
     end

--- a/lib/cb/responses/job/search_v3.rb
+++ b/lib/cb/responses/job/search_v3.rb
@@ -10,7 +10,7 @@ module Cb
         end
 
         def hash_containing_metadata
-          nil
+          'ResponseJobSearch'
         end
 
         def extract_models

--- a/lib/cb/responses/job/search_v3.rb
+++ b/lib/cb/responses/job/search_v3.rb
@@ -20,7 +20,7 @@ module Cb
         private
 
         def root_node
-          'APIResult'
+          'ResponseJobSearch'
         end
       end
     end

--- a/lib/cb/responses/job/search_v3.rb
+++ b/lib/cb/responses/job/search_v3.rb
@@ -1,0 +1,28 @@
+module Cb
+  module Responses
+    module Job
+      class SearchV3 < ApiResponse
+
+        protected
+
+        def validate_api_hash
+          required_response_field(root_node, response)
+        end
+
+        def hash_containing_metadata
+          nil
+        end
+
+        def extract_models
+          Models::JobResultsV3.new(response[root_node])
+        end
+
+        private
+
+        def root_node
+          'APIResult'
+        end
+      end
+    end
+  end
+end

--- a/lib/cb/utils/response_map.rb
+++ b/lib/cb/utils/response_map.rb
@@ -39,6 +39,8 @@ module Cb
             Cb::Requests::EmailSubscription::Retrieve => Cb::Responses::EmailSubscription::Response,
             Cb::Requests::EmailSubscription::Modify => Cb::Responses::EmailSubscription::Response,
 
+            Cb::Requests::JobSearch::Get => Cb::Responses::Job::SearchV3,
+
             Cb::Requests::Recommendations::Resume => Cb::Responses::Recommendations,
 
             Cb::Requests::Resumes::Get => Cb::Responses::Resume,

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '18.0.0'
+  VERSION = '17.1.0'
 end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '17.0.1'
+  VERSION = '18.0.0'
 end

--- a/spec/cb/models/implementations/job_results_v3_spec.rb
+++ b/spec/cb/models/implementations/job_results_v3_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+module Cb::Models
+  describe JobResultsV3 do
+    let(:search_response_hash) { YAML.load open('spec/support/response_stubs/search_result_v3.yml') }
+    let(:search_results) { JobResultsV3.new(search_response_hash) }
+    
+    describe '#api_result' do
+      
+      it 'returns a Hash' do
+        expect(search_results.api_response).to be_instance_of(Hash) 
+      end
+    end
+  end
+end

--- a/spec/cb/responses/job/search_v3_spec.rb
+++ b/spec/cb/responses/job/search_v3_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Cb::Responses::Job::SearchV3 do
+  
+  shared_examples 'search_v3_response' do |example_response_file|
+
+    let(:search_response_hash) { YAML.load open(example_response_file) }
+    let(:search_results) { Cb::Responses::Job::SearchV3.new(search_response_hash) }
+
+    describe '#model' do
+    
+      it 'returns a JobResultsV3' do
+        expect(search_results.model).to be_instance_of(Cb::Models::JobResultsV3) 
+      end
+    end
+  
+    describe '#response' do
+    
+      it 'returns a hash' do
+        expect(search_results.response).to be_instance_of(Hash)
+      end
+    end
+  end
+  
+  it_behaves_like "search_v3_response", 'spec/support/response_stubs/search_result_v3.yml'
+  it_behaves_like "search_v3_response", 'spec/support/response_stubs/company_colapse_search_result_v3.yml'
+
+end

--- a/spec/cb/responses/job/search_v3_spec.rb
+++ b/spec/cb/responses/job/search_v3_spec.rb
@@ -5,7 +5,7 @@ describe Cb::Responses::Job::SearchV3 do
   shared_examples 'search_v3_response' do |example_response_file|
 
     let(:search_response_hash) { YAML.load open(example_response_file) }
-    let(:search_results) { Cb::Responses::Job::SearchV3.new(search_response_hash) }
+    let(:search_results) { described_class.new(search_response_hash) }
 
     describe '#model' do
     

--- a/spec/support/response_stubs/company_colapse_search_result_v3.yml
+++ b/spec/support/response_stubs/company_colapse_search_result_v3.yml
@@ -1,78 +1,77 @@
-ResponseJobSearch:
-  total_pages: 12
-  total_count: 285
-  first_item_index: 0
-  last_item_index: 284
-  facets:
-    -
-      facet:
-        -
-          type: 'City'
-          items:
-            -
-              item:
-                -
-                  request_value: 'Atlanta'
-                  display_value: 'Atlanta'
-                  count: 1
-  data:
-    number_groups: ''
-    grouping_parameter: ''
-    GroupedJobResult:
-      number_jobs_in_group: 5
-      grouping_value:
-        results:
+total_pages: 12
+total_count: 285
+first_item_index: 0
+last_item_index: 284
+facets:
+  -
+    facet:
+      -
+        type: 'City'
+        items:
           -
-            jobResult:
-              company_name: 'Jerbs Inc.'
-              company_id: ''
-              id: 'CW12377908'
-              onet15_code: ''
-              onet15_friendly_title: ''
-              description_teaser: ''
-              distance: ''
-              employment_type: ''
-              education_required: ''
-              experience_required: ''
-              job_details_url: ''
-              location: ''
-              display_city: ''
-              city: ''
-              admin_area_1: ''
-              latitude: ''
-              longitude: ''
-              date_posted: ''
-              pay: ''
-              job_title: ''
-              apply_requirements:
-                -
-                  apply_requirement: ''
-              skills: ''
-              job_level: ''
-    search_metadata:
-      results_altered_by_users_search_preferences: true
-      search_locations:
+            item:
+              -
+                request_value: 'Atlanta'
+                display_value: 'Atlanta'
+                count: 1
+data:
+  number_groups: ''
+  grouping_parameter: ''
+  GroupedJobResult:
+    number_jobs_in_group: 5
+    grouping_value:
+      results:
         -
-          search_location:
+          jobResult:
+            company_name: 'Jerbs Inc.'
+            company_id: ''
+            id: 'CW12377908'
+            onet15_code: ''
+            onet15_friendly_title: ''
+            description_teaser: ''
+            distance: ''
+            employment_type: ''
+            education_required: ''
+            experience_required: ''
+            job_details_url: ''
+            location: ''
+            display_city: ''
             city: ''
             admin_area_1: ''
-            country_code: ''
-            postal_code: ''
-            radius: 25
-            valid: true
-    forensics:
-      request:
-        cobrand: ''
-        ipath: ''
-        count_limit: ''
-        page_number: ''
-        per_page: ''
-        host_site: ''
-        language: ''
-        user_id: ''
-        request_evidence_id: ''
-        reveal: ''
-      server_url: ''
-      ad_hoc_parameters : ''
-      solr_query: ''
-      solr_filters: ''
+            latitude: ''
+            longitude: ''
+            date_posted: ''
+            pay: ''
+            job_title: ''
+            apply_requirements:
+              -
+                apply_requirement: ''
+            skills: ''
+            job_level: ''
+  search_metadata:
+    results_altered_by_users_search_preferences: true
+    search_locations:
+      -
+        search_location:
+          city: ''
+          admin_area_1: ''
+          country_code: ''
+          postal_code: ''
+          radius: 25
+          valid: true
+  forensics:
+    request:
+      cobrand: ''
+      ipath: ''
+      count_limit: ''
+      page_number: ''
+      per_page: ''
+      host_site: ''
+      language: ''
+      user_id: ''
+      request_evidence_id: ''
+      reveal: ''
+    server_url: ''
+    ad_hoc_parameters : ''
+    solr_query: ''
+    solr_filters: ''

--- a/spec/support/response_stubs/company_colapse_search_result_v3.yml
+++ b/spec/support/response_stubs/company_colapse_search_result_v3.yml
@@ -76,4 +76,3 @@ APIResult:
       ad_hoc_parameters : ''
       solr_query: ''
       solr_filters: ''
-        

--- a/spec/support/response_stubs/company_colapse_search_result_v3.yml
+++ b/spec/support/response_stubs/company_colapse_search_result_v3.yml
@@ -1,0 +1,79 @@
+APIResult:
+  total_pages: 12
+  total_count: 285
+  first_item_index: 0
+  last_item_index: 284
+  facets:
+    -
+      facet:
+        -
+          type: 'City'
+          items:
+            -
+              item:
+                -
+                  request_value: 'Atlanta'
+                  display_value: 'Atlanta'
+                  count: 1
+  data:
+    number_groups: ''
+    grouping_parameter: ''
+    GroupedJobResult:
+      number_jobs_in_group: 5
+      grouping_value:
+        results:
+          -
+            jobResult:
+              company_name: 'Jerbs Inc.'
+              company_id: ''
+              id: 'CW12377908'
+              onet15_code: ''
+              onet15_friendly_title: ''
+              description_teaser: ''
+              distance: ''
+              employment_type: ''
+              education_required: ''
+              experience_required: ''
+              job_details_url: ''
+              location: ''
+              display_city: ''
+              city: ''
+              admin_area_1: ''
+              latitude: ''
+              longitude: ''
+              date_posted: ''
+              pay: ''
+              job_title: ''
+              apply_requirements:
+                -
+                  apply_requirement: ''
+              skills: ''
+              job_level: ''
+    search_metadata:
+      results_altered_by_users_search_preferences: true
+      search_locations:
+        -
+          search_location:
+            city: ''
+            admin_area_1: ''
+            country_code: ''
+            postal_code: ''
+            radius: 25
+            valid: true
+    forensics:
+      request:
+        cobrand: ''
+        ipath: ''
+        count_limit: ''
+        page_number: ''
+        per_page: ''
+        host_site: ''
+        language: ''
+        user_id: ''
+        request_evidence_id: ''
+        reveal: ''
+      server_url: ''
+      ad_hoc_parameters : ''
+      solr_query: ''
+      solr_filters: ''
+        

--- a/spec/support/response_stubs/company_colapse_search_result_v3.yml
+++ b/spec/support/response_stubs/company_colapse_search_result_v3.yml
@@ -1,4 +1,4 @@
-APIResult:
+ResponseJobSearch:
   total_pages: 12
   total_count: 285
   first_item_index: 0

--- a/spec/support/response_stubs/search_result_v3.yml
+++ b/spec/support/response_stubs/search_result_v3.yml
@@ -1,0 +1,102 @@
+APIResult:
+  total_pages: 12
+  total_count: 285
+  first_item_index: 0
+  last_item_index: 284
+  facets:
+    -
+      facet:
+        -
+          type: 'City'
+          items:
+            -
+              item:
+                -
+                  request_value: 'Atlanta'
+                  display_value: 'Atlanta'
+                  count: 1
+  data:
+    -
+      results:
+        -
+          jobResult:
+            company_name: 'Jerbs Inc.'
+            id: 'CW12377908'
+            onet15_code: ''
+            onet15_friendly_title: ''
+            description_teaser: ''
+            distance: ''
+            employment_type: ''
+            education_required: ''
+            experience_required: ''
+            job_details_url: ''
+            location: ''
+            display_city: ''
+            city: ''
+            admin_area_1: ''
+            latitude: ''
+            longitude: ''
+            date_posted: ''
+            pay: ''
+            job_title: ''
+            apply_requirements: []
+            skills: ''
+            job_level: ''
+            hostsite: 'US'
+          jobResult:
+            company_name: 'Happy Werks Inc.'
+            id: 'C212477965'
+            onet15_code: ''
+            onet15_friendly_title: ''
+            description_teaser: ''
+            distance: ''
+            employment_type: ''
+            education_required: ''
+            experience_required: ''
+            job_details_url: ''
+            location: ''
+            display_city: ''
+            city: ''
+            admin_area_1: ''
+            latitude: ''
+            longitude: ''
+            date_posted: ''
+            pay: ''
+            job_title: ''
+            apply_requirements: []
+            skills: ''
+            job_level: ''
+            hostsite: 'US'
+  search_metadata:
+    results_altered_by_users_search_preferences: true
+    search_locations:
+      -
+        search_location:
+          city: ''
+          admin_area_1: ''
+          country_code: ''
+          postal_code: ''
+          radius: 25
+          valid: true
+    geo_search_enabled: true
+    geo_search_filtered: true
+    results_are_grouped: true
+    jobsearch_evidence_id: ''
+  forensics:
+    request:
+      cobrand: ''
+      ipath: ''
+      count_limit: ''
+      page_number: ''
+      per_page: ''
+      host_site: ''
+      language: ''
+      user_id: ''
+      request_evidence_id: ''
+      reveal: ''
+    server_url: ''
+    ad_hoc_parameters : ''
+    solr_query: ''
+    solr_filters: ''
+    
+      

--- a/spec/support/response_stubs/search_result_v3.yml
+++ b/spec/support/response_stubs/search_result_v3.yml
@@ -1,4 +1,4 @@
-APIResult:
+ResponseJobSearch:
   total_pages: 12
   total_count: 285
   first_item_index: 0

--- a/spec/support/response_stubs/search_result_v3.yml
+++ b/spec/support/response_stubs/search_result_v3.yml
@@ -98,5 +98,3 @@ APIResult:
     ad_hoc_parameters : ''
     solr_query: ''
     solr_filters: ''
-    
-      

--- a/spec/support/response_stubs/search_result_v3.yml
+++ b/spec/support/response_stubs/search_result_v3.yml
@@ -1,100 +1,99 @@
-ResponseJobSearch:
-  total_pages: 12
-  total_count: 285
-  first_item_index: 0
-  last_item_index: 284
-  facets:
-    -
-      facet:
-        -
-          type: 'City'
-          items:
-            -
-              item:
-                -
-                  request_value: 'Atlanta'
-                  display_value: 'Atlanta'
-                  count: 1
-  data:
-    -
-      results:
-        -
-          jobResult:
-            company_name: 'Jerbs Inc.'
-            id: 'CW12377908'
-            onet15_code: ''
-            onet15_friendly_title: ''
-            description_teaser: ''
-            distance: ''
-            employment_type: ''
-            education_required: ''
-            experience_required: ''
-            job_details_url: ''
-            location: ''
-            display_city: ''
-            city: ''
-            admin_area_1: ''
-            latitude: ''
-            longitude: ''
-            date_posted: ''
-            pay: ''
-            job_title: ''
-            apply_requirements: []
-            skills: ''
-            job_level: ''
-            hostsite: 'US'
-          jobResult:
-            company_name: 'Happy Werks Inc.'
-            id: 'C212477965'
-            onet15_code: ''
-            onet15_friendly_title: ''
-            description_teaser: ''
-            distance: ''
-            employment_type: ''
-            education_required: ''
-            experience_required: ''
-            job_details_url: ''
-            location: ''
-            display_city: ''
-            city: ''
-            admin_area_1: ''
-            latitude: ''
-            longitude: ''
-            date_posted: ''
-            pay: ''
-            job_title: ''
-            apply_requirements: []
-            skills: ''
-            job_level: ''
-            hostsite: 'US'
-  search_metadata:
-    results_altered_by_users_search_preferences: true
-    search_locations:
+total_pages: 12
+total_count: 285
+first_item_index: 0
+last_item_index: 284
+facets:
+  -
+    facet:
       -
-        search_location:
+        type: 'City'
+        items:
+          -
+            item:
+              -
+                request_value: 'Atlanta'
+                display_value: 'Atlanta'
+                count: 1
+data:
+  -
+    results:
+      -
+        jobResult:
+          company_name: 'Jerbs Inc.'
+          id: 'CW12377908'
+          onet15_code: ''
+          onet15_friendly_title: ''
+          description_teaser: ''
+          distance: ''
+          employment_type: ''
+          education_required: ''
+          experience_required: ''
+          job_details_url: ''
+          location: ''
+          display_city: ''
           city: ''
           admin_area_1: ''
-          country_code: ''
-          postal_code: ''
-          radius: 25
-          valid: true
-    geo_search_enabled: true
-    geo_search_filtered: true
-    results_are_grouped: true
-    jobsearch_evidence_id: ''
-  forensics:
-    request:
-      cobrand: ''
-      ipath: ''
-      count_limit: ''
-      page_number: ''
-      per_page: ''
-      host_site: ''
-      language: ''
-      user_id: ''
-      request_evidence_id: ''
-      reveal: ''
-    server_url: ''
-    ad_hoc_parameters : ''
-    solr_query: ''
-    solr_filters: ''
+          latitude: ''
+          longitude: ''
+          date_posted: ''
+          pay: ''
+          job_title: ''
+          apply_requirements: []
+          skills: ''
+          job_level: ''
+          hostsite: 'US'
+        jobResult:
+          company_name: 'Happy Werks Inc.'
+          id: 'C212477965'
+          onet15_code: ''
+          onet15_friendly_title: ''
+          description_teaser: ''
+          distance: ''
+          employment_type: ''
+          education_required: ''
+          experience_required: ''
+          job_details_url: ''
+          location: ''
+          display_city: ''
+          city: ''
+          admin_area_1: ''
+          latitude: ''
+          longitude: ''
+          date_posted: ''
+          pay: ''
+          job_title: ''
+          apply_requirements: []
+          skills: ''
+          job_level: ''
+          hostsite: 'US'
+search_metadata:
+  results_altered_by_users_search_preferences: true
+  search_locations:
+    -
+      search_location:
+        city: ''
+        admin_area_1: ''
+        country_code: ''
+        postal_code: ''
+        radius: 25
+        valid: true
+  geo_search_enabled: true
+  geo_search_filtered: true
+  results_are_grouped: true
+  jobsearch_evidence_id: ''
+forensics:
+  request:
+    cobrand: ''
+    ipath: ''
+    count_limit: ''
+    page_number: ''
+    per_page: ''
+    host_site: ''
+    language: ''
+    user_id: ''
+    request_evidence_id: ''
+    reveal: ''
+  server_url: ''
+  ad_hoc_parameters : ''
+  solr_query: ''
+  solr_filters: ''


### PR DESCRIPTION
This adds v3 of the job search api to the library.  According to the search team there may be differences between the jobs returned.  We want to be able to quickly switch between calls to the v3 and v2 in case there are site performance issues.  To do this we believe both the v2 and v3 searches should be in the gem and higher level logic will make the determination of which to call.