### PR TITLE
Pegging us at 1.0 of webapi resume 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
+* 17.0.2 making sure we explicitly ask for version 1 of the consumer APIs
 * 17.0.1 adding posted_time and company_did to job results
 * 17.0.0 removed spot cms dependency
 * 16.3.0 changed api error response to use join instead of to_s
-* 16.2.2 change degree code to be degree which fixes compatibilty problems
+* 16.2.2 change degree code to be degree which fixes compatibility problems
 * 16.2.1 fix major or program in resume put. it was looking for the wrong value
 * 16.2.0 Added support for work experience ID in resume put
 * 16.1.0 Added support for handling a 401 unauthorized response. We should now raise specific UnauthorizedErrors.

--- a/lib/cb/requests/resumes/delete.rb
+++ b/lib/cb/requests/resumes/delete.rb
@@ -22,7 +22,7 @@ module Cb
           {
             'DeveloperKey' => Cb.configuration.dev_key,
             'HostSite' => args[:host_site] || Cb.configuration.host_site,
-            'Content-Type' => 'application/json'
+            'Content-Type' => 'application/json;version=1.0'
           }
         end
       end

--- a/lib/cb/requests/resumes/get.rb
+++ b/lib/cb/requests/resumes/get.rb
@@ -22,7 +22,7 @@ module Cb
           {
             'DeveloperKey' => Cb.configuration.dev_key,
             'HostSite' => Cb.configuration.host_site,
-            'Content-Type' => 'application/json'
+            'Content-Type' => 'application/json;version=1.0'
           }
         end
       end

--- a/lib/cb/requests/resumes/language_codes.rb
+++ b/lib/cb/requests/resumes/language_codes.rb
@@ -15,7 +15,7 @@ module Cb
         def headers
           {
               'DeveloperKey' => Cb.configuration.dev_key,
-              'Content-Type' => 'application/json'
+              'Content-Type' => 'application/json;version=1.0'
           }
         end
       end

--- a/lib/cb/requests/resumes/post.rb
+++ b/lib/cb/requests/resumes/post.rb
@@ -25,7 +25,7 @@ module Cb
         def headers
           {
             'HostSite' => Cb.configuration.host_site,
-            'Content-Type' => 'application/json',
+            'Content-Type' => 'application/json;version=1.0',
             'Authorization' => three_scale_bearer_token
           }
         end

--- a/lib/cb/requests/resumes/put.rb
+++ b/lib/cb/requests/resumes/put.rb
@@ -16,7 +16,7 @@ module Cb
           {
             'DeveloperKey' => Cb.configuration.dev_key,
             'HostSite' => Cb.configuration.host_site,
-            'Content-Type' => 'application/json'
+            'Content-Type' => 'application/json;version=1.0'
           }
         end
 

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '17.0.1'
+  VERSION = '17.0.2'
 end

--- a/spec/cb/requests/resumes/delete_spec.rb
+++ b/spec/cb/requests/resumes/delete_spec.rb
@@ -20,7 +20,7 @@ module Cb
           expect(request.headers).to eq({
               'DeveloperKey' => Cb.configuration.dev_key,
               'HostSite' => Cb.configuration.host_site,
-              'Content-Type' => 'application/json'
+              'Content-Type' => 'application/json;version=1.0'
           })
         end
 
@@ -46,7 +46,7 @@ module Cb
           expect(request.headers).to eq({
               'DeveloperKey' => Cb.configuration.dev_key,
               'HostSite' => Cb.configuration.host_site,
-              'Content-Type' => 'application/json'
+              'Content-Type' => 'application/json;version=1.0'
           })
         end
 

--- a/spec/cb/requests/resumes/get_spec.rb
+++ b/spec/cb/requests/resumes/get_spec.rb
@@ -6,7 +6,7 @@ module Cb
       {
         'DeveloperKey' => Cb.configuration.dev_key,
         'HostSite' => Cb.configuration.host_site,
-        'Content-Type' => 'application/json'
+        'Content-Type' => 'application/json;version=1.0'
       }
     }
     describe '#new' do

--- a/spec/cb/requests/resumes/language_codes_spec.rb
+++ b/spec/cb/requests/resumes/language_codes_spec.rb
@@ -5,7 +5,7 @@ module Cb
     let(:headers) {
       {
           'DeveloperKey' => Cb.configuration.dev_key,
-          'Content-Type' => 'application/json'
+          'Content-Type' => 'application/json;version=1.0'
       }
     }
 

--- a/spec/cb/requests/resumes/post_spec.rb
+++ b/spec/cb/requests/resumes/post_spec.rb
@@ -7,7 +7,7 @@ module Cb
     let(:headers) do
       {
         'HostSite' => Cb.configuration.host_site,
-        'Content-Type' => 'application/json',
+        'Content-Type' => 'application/json;version=1.0',
         'Authorization' => 'Bearer '
       }
     end

--- a/spec/cb/requests/resumes/put_spec.rb
+++ b/spec/cb/requests/resumes/put_spec.rb
@@ -22,7 +22,7 @@ module Cb
             {
               'DeveloperKey' => Cb.configuration.dev_key,
               'HostSite' => Cb.configuration.host_site,
-              'Content-Type' => 'application/json'
+              'Content-Type' => 'application/json;version=1.0'
             }
           )
         end
@@ -48,7 +48,7 @@ module Cb
             {
               'DeveloperKey' => Cb.configuration.dev_key,
               'HostSite' => Cb.configuration.host_site,
-              'Content-Type' => 'application/json'
+              'Content-Type' => 'application/json;version=1.0'
             }
           )
         end


### PR DESCRIPTION
Versioning in the new APIs is via header and its assumed that if you dont ask for a version you always get latest.  I am changing the format of the APIs a lot so I'm pegging us at the old format until such time I can convert our calls.