### PR TITLE
Add API timings to observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
-* 18.0.0 Start sending timings to all observers for API calls
+* 17.1.0 Start sending timings to all observers for API calls
 * 17.0.2 making sure we explicitly ask for version 1 of the consumer APIs
 * 17.0.1 adding posted_time and company_did to job results
 * 17.0.0 removed spot cms dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
+* 18.0.0 Start sending timings to all observers for API calls
 * 17.0.2 making sure we explicitly ask for version 1 of the consumer APIs
 * 17.0.1 adding posted_time and company_did to job results
 * 17.0.0 removed spot cms dependency

--- a/lib/cb/models/api_call_model.rb
+++ b/lib/cb/models/api_call_model.rb
@@ -1,6 +1,6 @@
 module Cb
   module Models
-    class ApiCall < Struct.new(:api_call_type, :path, :options, :response)
+    class ApiCall < Struct.new(:api_call_type, :path, :options, :response, :elapsed_time)
     end
   end
 end

--- a/lib/cb/utils/api.rb
+++ b/lib/cb/utils/api.rb
@@ -47,7 +47,7 @@ module Cb
       def execute_http_request(http_method, uri, path, options={}, &block)
         self.class.base_uri(uri || Cb.configuration.base_uri)
         start_time = Time.now.to_f
-        cb_event(:"cb_#{ http_method }_before", path, options, nil, start_time - start_time, &block)
+        cb_event(:"cb_#{ http_method }_before", path, options, nil, 0.0, &block)
         response = self.class.method(http_method).call(path, options)
         cb_event(:"cb_#{ http_method }_after", path, options, response, Time.now.to_f - start_time, &block)
         validate_response(response)

--- a/lib/cb/utils/api.rb
+++ b/lib/cb/utils/api.rb
@@ -107,15 +107,15 @@ module Cb
         validated_response
       end
 
-      def api_call_model(api_call_type, path, options, response)
-        Cb::Models::ApiCall.new(api_call_type, path, options, response)
+      def api_call_model(api_call_type, path, options, response, time_elapsed)
+        Cb::Models::ApiCall.new(api_call_type, path, options, response, time_elapsed)
       end
 
       def cb_event(api_call_type, path, options, response, time_elapsed, &block)
-        call_model = api_call_model(api_call_type, path, options, response)
+        call_model = api_call_model(api_call_type, path, options, response, time_elapsed)
         block.call(call_model) if block_given?
         changed(true)
-        notify_observers(call_model, time_elapsed)
+        notify_observers(call_model)
       end
 
       def ensure_non_nil_metavalues(obj)

--- a/lib/cb/utils/api.rb
+++ b/lib/cb/utils/api.rb
@@ -111,10 +111,11 @@ module Cb
       end
 
       def cb_event(api_call_type, path, options, response, &block)
+        start_time = Time.now.to_f
         call_model = api_call_model(api_call_type, path, options, response)
         block.call(call_model) if block_given?
         changed(true)
-        notify_observers(call_model)
+        notify_observers(call_model, Time.now.to_f - start_time)
       end
 
       def ensure_non_nil_metavalues(obj)

--- a/lib/cb/utils/api.rb
+++ b/lib/cb/utils/api.rb
@@ -47,9 +47,9 @@ module Cb
       def execute_http_request(http_method, uri, path, options={}, &block)
         self.class.base_uri(uri || Cb.configuration.base_uri)
         start_time = Time.now.to_f
-        cb_event(:"cb_#{http_method.to_s}_before", path, options, nil, start_time - start_time, &block)
+        cb_event(:"cb_#{ http_method }_before", path, options, nil, start_time - start_time, &block)
         response = self.class.method(http_method).call(path, options)
-        cb_event(:"cb_#{http_method.to_s}_after", path, options, response, Time.now.to_f - start_time, &block)
+        cb_event(:"cb_#{ http_method }_after", path, options, response, Time.now.to_f - start_time, &block)
         validate_response(response)
       end
 

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '17.0.2'
+  VERSION = '18.0.0'
 end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '18.0.0'
+  VERSION = '17.1.0'
 end

--- a/spec/cb/utils/api_spec.rb
+++ b/spec/cb/utils/api_spec.rb
@@ -27,17 +27,19 @@ module Cb
       describe '#cb_get' do
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
+          let(:observer) { Mocks::Observer.new }
           before{
             allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
             allow(Api).to receive(:get).with(path, options).and_return(response)
+            allow(Mocks::Observer).to receive(:new).and_return(observer)
           }
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect_any_instance_of(Mocks::Observer).to receive(:update).at_most(2).times
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(2).times
             api.cb_get(path)
           end
         end
-        it 'sends #post to HttParty' do
+        it 'sends #get to HttParty' do
           expect(Api).to receive(:get).with(path, options)
           api.cb_get(path)
         end
@@ -71,13 +73,15 @@ module Cb
       describe '#cb_post' do
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
+          let(:observer) { Mocks::Observer.new }
           before{
             allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
             allow(Api).to receive(:post).with(path, options).and_return(response)
+            allow(Mocks::Observer).to receive(:new).and_return(observer)
           }
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect_any_instance_of(Mocks::Observer).to receive(:update).at_most(2).times
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(2).times
             api.cb_post(path)
           end
         end
@@ -115,13 +119,15 @@ module Cb
       describe '#cb_put' do
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
+          let(:observer) { Mocks::Observer.new }
           before{
             allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
             allow(Api).to receive(:put).with(path, options).and_return(response)
+            allow(Mocks::Observer).to receive(:new).and_return(observer)
           }
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect_any_instance_of(Mocks::Observer).to receive(:update).at_most(2).times
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(2).times
             api.cb_put(path)
           end
         end
@@ -160,13 +166,15 @@ module Cb
       describe '#cb_delete' do
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
+          let(:observer) { Mocks::Observer.new }
           before{
             allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
             allow(Api).to receive(:delete).with(path, options).and_return(response)
+            allow(Mocks::Observer).to receive(:new).and_return(observer)
           }
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect_any_instance_of(Mocks::Observer).to receive(:update).at_most(2).times
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(2).times
             api.cb_delete(path)
           end
         end

--- a/spec/cb/utils/api_spec.rb
+++ b/spec/cb/utils/api_spec.rb
@@ -13,9 +13,10 @@ module Cb
         end
 
         context 'when we have observers' do
-          before{
+          before do
             allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
-           }
+          end
+
           it 'returns an instance of Api with the observers attached' do
             expect(Mocks::Observer).to receive(:new)
             expect_any_instance_of(Cb::Utils::Api).to receive(:add_observer)
@@ -28,27 +29,30 @@ module Cb
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
           let(:observer) { Mocks::Observer.new }
-          before{
+
+          before do
             allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
             allow(Api).to receive(:get).with(path, options).and_return(response)
             allow(Mocks::Observer).to receive(:new).and_return(observer)
-          }
+          end
+
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
             expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(2).times
             api.cb_get(path)
           end
         end
+
         it 'sends #get to HttParty' do
           expect(Api).to receive(:get).with(path, options)
           api.cb_get(path)
         end
 
         context 'When Cb base_uri is configured' do
-          before {
+          before do
             Cb.configuration.base_uri = 'http://www.applecat.com'
             allow(Api).to receive(:get).with(path, options)
-          }
+          end
 
           it 'sets base_uri on Api' do
             api.cb_get(path)
@@ -58,9 +62,10 @@ module Cb
 
         context 'When a response is returned' do
           let(:response) { { success: 'yeah' } }
-          before {
+
+          before do
             allow(Api).to receive(:get).with(path, options).and_return(response)
-          }
+          end
 
           it 'sends #validate to ResponseValidator with the response' do
             expect(ResponseValidator).to receive(:validate).with(response).and_return(response)
@@ -74,27 +79,30 @@ module Cb
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
           let(:observer) { Mocks::Observer.new }
-          before{
+
+          before do
             allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
             allow(Api).to receive(:post).with(path, options).and_return(response)
             allow(Mocks::Observer).to receive(:new).and_return(observer)
-          }
+          end
+
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
             expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(2).times
             api.cb_post(path)
           end
         end
+
         it 'sends #post to HttParty' do
           expect(Api).to receive(:post).with(path, options)
           api.cb_post(path)
         end
 
         context 'When Cb base_uri is configured' do
-          before {
+          before do
             Cb.configuration.base_uri = 'http://www.bananadog.org'
             allow(Api).to receive(:post).with(path, options)
-          }
+          end
 
           it 'sets base_uri on Api' do
             api.cb_post(path)
@@ -104,43 +112,46 @@ module Cb
 
         context 'When a response is returned' do
           let(:response) { { success: 'yeah' } }
-          before {
+
+          before do
             allow(Api).to receive(:post).with(path, options).and_return(response)
-          }
+          end
 
           it 'sends #validate to ResponseValidator with the response' do
             expect(ResponseValidator).to receive(:validate).with(response).and_return(response)
             api.cb_post(path)
           end
         end
-
       end
 
       describe '#cb_put' do
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
           let(:observer) { Mocks::Observer.new }
-          before{
+
+          before do
             allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
             allow(Api).to receive(:put).with(path, options).and_return(response)
             allow(Mocks::Observer).to receive(:new).and_return(observer)
-          }
+          end
+
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
             expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(2).times
             api.cb_put(path)
           end
         end
+
         it 'sends #put to HttParty' do
           expect(Api).to receive(:put).with(path, options)
           api.cb_put(path)
         end
 
         context 'When Cb base_uri is configured' do
-          before {
+          before do
             Cb.configuration.base_uri = 'http://www.kylerox.org'
             allow(Api).to receive(:put).with(path, options)
-          }
+          end
 
           it 'sets base_uri on Api' do
             api.cb_put(path)
@@ -151,43 +162,46 @@ module Cb
 
         context 'When a response is returned' do
           let(:response) { { success: 'yeah' } }
-          before {
+
+          before do
             allow(Api).to receive(:put).with(path, options).and_return(response)
-          }
+          end
 
           it 'sends #validate to ResponseValidator with the response' do
             expect(ResponseValidator).to receive(:validate).with(response).and_return(response)
             api.cb_put(path)
           end
         end
-
-        end
+      end
 
       describe '#cb_delete' do
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
           let(:observer) { Mocks::Observer.new }
-          before{
+
+          before do
             allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
             allow(Api).to receive(:delete).with(path, options).and_return(response)
             allow(Mocks::Observer).to receive(:new).and_return(observer)
-          }
+          end
+
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
             expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(2).times
             api.cb_delete(path)
           end
         end
+
         it 'sends #delete to HttParty' do
           expect(Api).to receive(:delete).with(path, options)
           api.cb_delete(path)
         end
 
         context 'When Cb base_uri is configured' do
-          before {
+          before do
             Cb.configuration.base_uri = 'http://www.kylerox.org'
             allow(Api).to receive(:delete).with(path, options)
-          }
+          end
 
           it 'sets base_uri on Api' do
             api.cb_delete(path)
@@ -198,42 +212,45 @@ module Cb
 
         context 'When a response is returned' do
           let(:response) { { success: 'yeah' } }
-          before {
+
+          before do
             allow(Api).to receive(:delete).with(path, options).and_return(response)
-          }
+          end
 
           it 'sends #validate to ResponseValidator with the response' do
             expect(ResponseValidator).to receive(:validate).with(response).and_return(response)
             api.cb_delete(path)
           end
         end
-
       end
 
       describe '#execute_http_request' do
         context ':delete' do
           context 'when we have observers' do
             let(:response) { { success: 'yeah' } }
-            before{
+
+            before do
               allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
               allow(Api).to receive(:delete).with(path, options).and_return(response)
-            }
+            end
+
             it 'will notify the observers' do
               expect(api).to receive(:notify_observers).twice.and_call_original
               expect_any_instance_of(Mocks::Observer).to receive(:update).at_most(2).times
               api.execute_http_request(:delete, nil, path)
             end
           end
+
           it 'sends #delete to HttParty' do
             expect(Api).to receive(:delete).with(path, options)
             api.execute_http_request(:delete, nil, path)
           end
 
           context 'When Cb base_uri is configured' do
-            before {
+            before do
               Cb.configuration.base_uri = 'http://www.kylerox.org'
               allow(Api).to receive(:delete).with(path, options)
-            }
+            end
 
             it 'sets base_uri on Api' do
               api.execute_http_request(:delete, nil, path)
@@ -244,9 +261,10 @@ module Cb
 
           context 'When a response is returned' do
             let(:response) { { success: 'yeah' } }
-            before {
+
+            before do
               allow(Api).to receive(:delete).with(path, options).and_return(response)
-            }
+            end
 
             it 'sends #validate to ResponseValidator with the response' do
               expect(ResponseValidator).to receive(:validate).with(response).and_return(response)
@@ -259,24 +277,27 @@ module Cb
       describe '#base_uri' do
         let(:base_uri) { 'http://www.careerbuilder.com' }
         let(:default_uri) { 'http://www.kylerox.org' }
-        before {
+
+        before do
           Cb.configuration.base_uri = default_uri
           allow(Api).to receive(:delete).with(path, options)
-        }
+        end
 
         context 'passes a base uri' do
-          before {
+          before do
             api.execute_http_request(:delete, base_uri, path)
-          }
+          end
+
           it 'sets an override' do
             expect(Api.base_uri).to eq base_uri
           end
         end
 
         context 'passes nil' do
-          before {
+          before do
             api.execute_http_request(:delete, nil, path)
-          }
+          end
+
           it 'doesn\'t set an override' do
             expect(Api.base_uri).to eq default_uri
           end

--- a/spec/cb/utils/api_spec.rb
+++ b/spec/cb/utils/api_spec.rb
@@ -37,8 +37,11 @@ module Cb
 
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), 0).at_most(1).times
-            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(1).times
+            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_get_before", '/moom', {},
+                                                              nil, 0.0).at_most(1).times.and_call_original
+            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_get_after", '/moom', {},
+                                                              { success: 'yeah' }, instance_of(Float)).at_most(1).times.and_call_original
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall)).at_most(2).times
             api.cb_get(path)
           end
         end
@@ -84,8 +87,11 @@ module Cb
 
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), 0).at_most(1).times
-            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(1).times
+            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_post_before", '/moom', {},
+                                                              nil, 0.0).at_most(1).times.and_call_original
+            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_post_after", '/moom', {},
+                                                              { success: 'yeah' }, instance_of(Float)).at_most(1).times.and_call_original
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall)).at_most(2).times
             api.cb_post(path)
           end
         end
@@ -131,8 +137,11 @@ module Cb
 
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), 0).at_most(1).times
-            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(1).times
+            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_put_before", '/moom', {},
+                                                              nil, 0.0).at_most(1).times.and_call_original
+            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_put_after", '/moom', {},
+                                                              { success: 'yeah' }, instance_of(Float)).at_most(1).times.and_call_original
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall)).at_most(2).times
             api.cb_put(path)
           end
         end
@@ -179,8 +188,11 @@ module Cb
 
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), 0).at_most(1).times
-            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(1).times
+            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_delete_before", '/moom', {},
+                                                              nil, 0.0).at_most(1).times.and_call_original
+            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_delete_after", '/moom', {},
+                                                              { success: 'yeah' }, instance_of(Float)).at_most(1).times.and_call_original
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall)).at_most(2).times
             api.cb_delete(path)
           end
         end

--- a/spec/cb/utils/api_spec.rb
+++ b/spec/cb/utils/api_spec.rb
@@ -6,6 +6,12 @@ module Cb
       let(:api) { Api.instance }
       let(:path) { '/moom' }
       let(:options) { {} }
+      let(:observer) { Mocks::Observer.new }
+
+      before do
+        allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
+        allow(Mocks::Observer).to receive(:new).and_return(observer)
+      end
 
       describe '#factory' do
         it 'returns a new instance of the api class' do
@@ -13,10 +19,6 @@ module Cb
         end
 
         context 'when we have observers' do
-          before do
-            allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
-          end
-
           it 'returns an instance of Api with the observers attached' do
             expect(Mocks::Observer).to receive(:new)
             expect_any_instance_of(Cb::Utils::Api).to receive(:add_observer)
@@ -28,17 +30,15 @@ module Cb
       describe '#cb_get' do
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
-          let(:observer) { Mocks::Observer.new }
 
           before do
-            allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
             allow(Api).to receive(:get).with(path, options).and_return(response)
-            allow(Mocks::Observer).to receive(:new).and_return(observer)
           end
 
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(2).times
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), 0).at_most(1).times
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(1).times
             api.cb_get(path)
           end
         end
@@ -72,23 +72,20 @@ module Cb
             api.cb_get(path)
           end
         end
-
       end
 
       describe '#cb_post' do
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
-          let(:observer) { Mocks::Observer.new }
 
           before do
-            allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
             allow(Api).to receive(:post).with(path, options).and_return(response)
-            allow(Mocks::Observer).to receive(:new).and_return(observer)
           end
 
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(2).times
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), 0).at_most(1).times
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(1).times
             api.cb_post(path)
           end
         end
@@ -127,17 +124,15 @@ module Cb
       describe '#cb_put' do
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
-          let(:observer) { Mocks::Observer.new }
 
           before do
-            allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
             allow(Api).to receive(:put).with(path, options).and_return(response)
-            allow(Mocks::Observer).to receive(:new).and_return(observer)
           end
 
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(2).times
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), 0).at_most(1).times
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(1).times
             api.cb_put(path)
           end
         end
@@ -177,17 +172,15 @@ module Cb
       describe '#cb_delete' do
         context 'when we have observers' do
           let(:response) { { success: 'yeah' } }
-          let(:observer) { Mocks::Observer.new }
 
           before do
-            allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
             allow(Api).to receive(:delete).with(path, options).and_return(response)
-            allow(Mocks::Observer).to receive(:new).and_return(observer)
           end
 
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(2).times
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), 0).at_most(1).times
+            expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall), instance_of(Float)).at_most(1).times
             api.cb_delete(path)
           end
         end
@@ -230,13 +223,12 @@ module Cb
             let(:response) { { success: 'yeah' } }
 
             before do
-              allow(Cb.configuration).to receive(:observers).and_return(Array(Mocks::Observer))
               allow(Api).to receive(:delete).with(path, options).and_return(response)
             end
 
             it 'will notify the observers' do
               expect(api).to receive(:notify_observers).twice.and_call_original
-              expect_any_instance_of(Mocks::Observer).to receive(:update).at_most(2).times
+              expect(observer).to receive(:update).at_most(2).times
               api.execute_http_request(:delete, nil, path)
             end
           end

--- a/spec/support/mocks/observer.rb
+++ b/spec/support/mocks/observer.rb
@@ -1,7 +1,7 @@
 module Mocks
   class Observer
-    def update(api_call)
-      puts "hello I am observer for #{api_call.api_call_type.to_s} #{api_call.path}"
+    def update(api_call, time_elapsed)
+      # puts "hello I am observer for #{api_call.api_call_type.to_s} #{api_call.path}"
     end
   end
 end

--- a/spec/support/mocks/observer.rb
+++ b/spec/support/mocks/observer.rb
@@ -1,6 +1,6 @@
 module Mocks
   class Observer
-    def update(api_call, time_elapsed)
+    def update(api_call)
       # puts "hello I am observer for #{api_call.api_call_type.to_s} #{api_call.path}"
     end
   end

--- a/spec/support/mocks/observer.rb
+++ b/spec/support/mocks/observer.rb
@@ -1,7 +1,6 @@
 module Mocks
   class Observer
     def update(api_call)
-      # puts "hello I am observer for #{api_call.api_call_type.to_s} #{api_call.path}"
     end
   end
 end


### PR DESCRIPTION
Lay the groundwork for starting to collect API call timings via our existing observers like https://github.com/cbdr/consumer-main/blob/master/config/initializers/cb_api.rb#L26-L48 and https://github.com/cbdr/consumer-domain/blob/master/lib/rails/cb_api_observer.rb