### PR TITLE
Simulate auth outage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
-* 17.3.0 Set `ENV['SIMULATE_AUTH_OUTAGE']` to true to automagically throw a `Cb::ServiceUnavailableError` 
-         for all API calls.
+* 17.3.0 Set `ENV['SIMULATE_AUTH_OUTAGE']` to true to throw a `Cb::ServiceUnavailableError` for all API calls.
 * 17.2.0 Give back more information about the API caller for timings
 * 17.1.0 Start sending timings to all observers for API calls
 * 17.0.2 making sure we explicitly ask for version 1 of the consumer APIs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
+* 17.3.0 Set `ENV['SIMULATE_AUTH_OUTAGE']` to true to automagically throw a `Cb::ServiceUnavailableError` 
+         for all API calls.
 * 17.2.0 Give back more information about the API caller for timings
 * 17.1.0 Start sending timings to all observers for API calls
 * 17.0.2 making sure we explicitly ask for version 1 of the consumer APIs

--- a/lib/cb/utils/validator.rb
+++ b/lib/cb/utils/validator.rb
@@ -14,8 +14,12 @@ module Cb
 
       def raise_response_code_errors(response)
         code = response.code rescue nil
-        raise Cb::ServiceUnavailableError if code == 503
+        raise Cb::ServiceUnavailableError if (code == 503 || simulate_auth_outage?)
         raise Cb::UnauthorizedError if code == 401
+      end
+
+      def simulate_auth_outage?
+        ENV['SIMULATE_AUTH_OUTAGE'].to_s.downcase == 'true'
       end
 
       def process_response_body(response)

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '17.1.0'
+  VERSION = '17.2.0'
 end

--- a/lib/cb/version.rb
+++ b/lib/cb/version.rb
@@ -1,3 +1,3 @@
 module Cb
-  VERSION = '17.2.0'
+  VERSION = '17.3.0'
 end

--- a/spec/cb/utils/validator_spec.rb
+++ b/spec/cb/utils/validator_spec.rb
@@ -48,9 +48,16 @@ module Cb
       expect(validation.empty?).to be_truthy
     end
 
-    it 'should raise a ServiceUnavailableError when status code is 503' do
-      allow(response).to receive(:code).and_return 503
-      expect{ ResponseValidator.validate(response) }.to raise_error(Cb::ServiceUnavailableError)
+    context 'raises a ServiceUnavailableError' do
+      it 'when status code is 503' do
+        allow(response).to receive(:code).and_return 503
+        expect { ResponseValidator.validate(response) }.to raise_error(Cb::ServiceUnavailableError)
+      end
+
+      it 'when simulation flag is turned on via ENV' do
+        allow(ENV).to receive(:[]).and_return 'true'
+        expect { ResponseValidator.validate(response) }.to raise_error(Cb::ServiceUnavailableError)
+      end
     end
 
     it 'should raise an UnauthorizedError when status code is 401' do


### PR DESCRIPTION
Exactly what the title says: with this PR, you'll be able to set an environment variable to cause all API calls to throw a `Cb:: ServiceUnavailableError` error. 

To do it:
```ruby
# in ruby
ENV['SIMULATE_AUTH_OUTAGE'] = 'true'
```

```bash
# in a .env file or exported to system/user ENV:
SIMULATE_AUTH_OUTAGE=true
```