### PR TITLE
Adding copyright to specs

### DIFF
--- a/spec/cb/api_spec.rb
+++ b/spec/cb/api_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 describe Cb::Utils::Api do
@@ -6,8 +16,6 @@ describe Cb::Utils::Api do
       client = Cb::Utils::Api.new
       expect(client.class.headers).to have_key('accept-encoding')
       expect(client.class.headers['accept-encoding']).to eq('deflate, gzip')
-
     end
   end
-
 end

--- a/spec/cb/cb_spec.rb
+++ b/spec/cb/cb_spec.rb
@@ -1,7 +1,16 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 describe Cb do
-
   context '#configure' do
     context 'when called with a block' do
       it 'yields a default configuration to play with' do

--- a/spec/cb/client_spec.rb
+++ b/spec/cb/client_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 require 'support/mocks/callback'
 require 'support/mocks/request'
@@ -9,7 +19,7 @@ module Cb
 
     context 'initialize' do
       it 'should not use a callback block' do
-        client = Cb::Client.new()
+        client = Cb::Client.new
         expect(client.callback_block).to eq(nil)
       end
 
@@ -26,14 +36,13 @@ module Cb
 
       it 'should call a custom callback method' do
         callback_test = nil
-        client = Cb::Client.new { |callback| callback_test = callback}
+        client = Cb::Client.new { |callback| callback_test = callback }
         client.callback_block.call(@callback_value)
         expect(callback_test).to eq(@callback_value)
       end
     end
 
     context 'api call no block' do
-
       let(:mock_api) { double(Cb::Utils::Api) }
 
       before :each do
@@ -42,7 +51,7 @@ module Cb
 
       context 'post' do
         before :each do
-          allow(mock_api).to receive(:execute_http_request).and_return(Hash.new)
+          allow(mock_api).to receive(:execute_http_request).and_return({})
           allow(mock_api).to receive(:append_api_responses)
           allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
           allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
@@ -51,9 +60,9 @@ module Cb
         end
 
         it 'should call the api using post' do
-          expect(mock_api).to receive(:execute_http_request).
-              with(:post, base_uri, 'parts unknown', {:query=>nil, :headers=>nil, :body=>nil}).
-              and_return(Hash.new)
+          expect(mock_api).to receive(:execute_http_request)
+            .with(:post, base_uri, 'parts unknown', query: nil, headers: nil, body: nil)
+            .and_return({})
 
           @client.execute(@request)
         end
@@ -61,7 +70,7 @@ module Cb
 
       context 'get' do
         before :each do
-          allow(mock_api).to receive(:execute_http_request).and_return(Hash.new)
+          allow(mock_api).to receive(:execute_http_request).and_return({})
           allow(mock_api).to receive(:append_api_responses)
           allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
           allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
@@ -70,9 +79,9 @@ module Cb
         end
 
         it 'should call the api using get' do
-          expect(mock_api).to receive(:execute_http_request).
-              with(:get, base_uri, 'parts unknown', {:query=>nil, :headers=>nil, :body=>nil}).
-              and_return(Hash.new)
+          expect(mock_api).to receive(:execute_http_request)
+            .with(:get, base_uri, 'parts unknown', query: nil, headers: nil, body: nil)
+            .and_return({})
 
           @client.execute(@request)
         end
@@ -80,7 +89,7 @@ module Cb
 
       context 'put' do
         before :each do
-          allow(mock_api).to receive(:execute_http_request).and_return(Hash.new)
+          allow(mock_api).to receive(:execute_http_request).and_return({})
           allow(mock_api).to receive(:append_api_responses)
           allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
           allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
@@ -89,17 +98,15 @@ module Cb
         end
 
         it 'should call the api using put' do
-          expect(mock_api).to receive(:execute_http_request).
-              with(:put, base_uri, 'parts unknown', {:query=>nil, :headers=>nil, :body=>nil}).
-              and_return(Hash.new)
+          expect(mock_api).to receive(:execute_http_request)
+            .with(:put, base_uri, 'parts unknown', query: nil, headers: nil, body: nil)
+            .and_return({})
 
           @client.execute(@request)
         end
       end
-
     end
     context 'api call with block' do
-
       let(:mock_api) { double(Cb::Utils::Api) }
 
       before :each do
@@ -108,7 +115,7 @@ module Cb
 
       context 'post' do
         before :each do
-          allow(mock_api).to receive(:execute_http_request).and_return(Hash.new)
+          allow(mock_api).to receive(:execute_http_request).and_return({})
           allow(mock_api).to receive(:append_api_responses)
           allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
           allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
@@ -117,10 +124,10 @@ module Cb
         end
 
         it 'should call the api using post' do
-          expect(mock_api).to receive(:execute_http_request).
-              with(:post, base_uri, 'parts unknown', {:query=>nil, :headers=>nil, :body=>nil}).
-              and_yield("test").
-              and_return(Hash.new)
+          expect(mock_api).to receive(:execute_http_request)
+            .with(:post, base_uri, 'parts unknown', query: nil, headers: nil, body: nil)
+            .and_yield('test')
+            .and_return({})
 
           @client.execute(@request)
         end
@@ -128,7 +135,7 @@ module Cb
 
       context 'get' do
         before :each do
-          allow(mock_api).to receive(:execute_http_request).and_return(Hash.new)
+          allow(mock_api).to receive(:execute_http_request).and_return({})
           allow(mock_api).to receive(:append_api_responses)
           allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
           allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
@@ -137,10 +144,10 @@ module Cb
         end
 
         it 'should call the api using get' do
-          expect(mock_api).to receive(:execute_http_request).
-              with(:get, base_uri, 'parts unknown', {:query=>nil, :headers=>nil, :body=>nil}).
-              and_yield("test").
-              and_return(Hash.new)
+          expect(mock_api).to receive(:execute_http_request)
+            .with(:get, base_uri, 'parts unknown', query: nil, headers: nil, body: nil)
+            .and_yield('test')
+            .and_return({})
 
           @client.execute(@request)
         end
@@ -148,7 +155,7 @@ module Cb
 
       context 'put' do
         before :each do
-          allow(mock_api).to receive(:execute_http_request).and_return(Hash.new)
+          allow(mock_api).to receive(:execute_http_request).and_return({})
           allow(mock_api).to receive(:append_api_responses)
           allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
           allow(Cb::Utils::ResponseMap).to receive(:response_for).and_return(Mocks::Response)
@@ -157,17 +164,14 @@ module Cb
         end
 
         it 'should call the api using put' do
-          expect(mock_api).to receive(:execute_http_request).
-              with(:put, base_uri, 'parts unknown', {:query=>nil, :headers=>nil, :body=>nil}).
-              and_yield("test").
-              and_return(Hash.new)
+          expect(mock_api).to receive(:execute_http_request)
+            .with(:put, base_uri, 'parts unknown', query: nil, headers: nil, body: nil)
+            .and_yield('test')
+            .and_return({})
 
           @client.execute(@request)
         end
       end
-
     end
-
-
   end
 end

--- a/spec/cb/clients/anon_saved_search_spec.rb
+++ b/spec/cb/clients/anon_saved_search_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Clients::AnonSavedSearch.new do
-
     before :each do
       @args = {
         'EmailAddress' => 'test@test.com',
@@ -20,9 +29,9 @@ module Cb
 
     context '#create' do
       def stub_api_request
-        stub_request(:post, uri_stem(Cb.configuration.uri_anon_saved_search_create)).
-          with(:body => anything).
-          to_return(:body => @response_body.to_json)
+        stub_request(:post, uri_stem(Cb.configuration.uri_anon_saved_search_create))
+          .with(body: anything)
+          .to_return(body: @response_body.to_json)
       end
 
       context 'when everything is working smoothly' do
@@ -53,9 +62,9 @@ module Cb
     context '#delete' do
       context 'when everything is working smoothly' do
         def stub_api_request
-          stub_request(:post, uri_stem(Cb.configuration.uri_anon_saved_search_delete.to_s)).
-            with(:body => anything).
-            to_return(:body => { 'Errors' => '', 'Status' => 'Success' }.to_json)
+          stub_request(:post, uri_stem(Cb.configuration.uri_anon_saved_search_delete.to_s))
+            .with(body: anything)
+            .to_return(body: { 'Errors' => '', 'Status' => 'Success' }.to_json)
         end
 
         before :each do
@@ -73,6 +82,5 @@ module Cb
         end
       end
     end # delete
-
   end
 end

--- a/spec/cb/clients/application_external_spec.rb
+++ b/spec/cb/clients/application_external_spec.rb
@@ -1,11 +1,18 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
-
 
 module Cb
   describe Cb::Clients::ApplicationExternal do
-
     context '#submit_app' do
-
       context 'when the parameter not the correct type' do
         it 'should raise a Cb::IncomingParamIsWrongTypeException' do
           expect { Cb.application_external.submit_app(Object.new) }.to raise_error Cb::IncomingParamIsWrongTypeException
@@ -13,8 +20,8 @@ module Cb
       end
 
       def stub_api_call_to_return(body_content)
-        stub_request(:post, uri_stem(Cb.configuration.uri_application_external)).with(:body => anything).
-          to_return(:body => body_content.to_json)
+        stub_request(:post, uri_stem(Cb.configuration.uri_application_external)).with(body: anything)
+          .to_return(body: body_content.to_json)
       end
 
       def submit_app(app)
@@ -22,17 +29,17 @@ module Cb
       end
 
       context 'when everything is working correctly' do
-        let(:external_app) { Cb::Models::ApplicationExternal.new({job_did: 'did', email: 'bogus@bogus.org', ipath: 'bogus', site_id: 'bogus'}) }
+        let(:external_app) { Cb::Models::ApplicationExternal.new(job_did: 'did', email: 'bogus@bogus.org', ipath: 'bogus', site_id: 'bogus') }
 
         it 'the same application object is returned that is supplied for input' do
-          stub_api_call_to_return(Hash.new)
+          stub_api_call_to_return({})
           app = submit_app(external_app)
           expect(app).to eq external_app
           expect(app.object_id).to eq external_app.object_id
         end
 
         context 'if the ApplyUrl field comes back in the response' do
-          before(:each) { stub_api_call_to_return({'ApplyUrl' => 'https://bacondreamz.net'}) }
+          before(:each) { stub_api_call_to_return('ApplyUrl' => 'https://bacondreamz.net') }
 
           it 'the ApplyUrl is set on the returned app' do
             app = submit_app(external_app)
@@ -41,7 +48,7 @@ module Cb
         end
 
         context 'if the ApplyUrl field is not in the response' do
-          before(:each) { stub_api_call_to_return(Hash.new) }
+          before(:each) { stub_api_call_to_return({}) }
 
           it 'the ApplyUrl on the returned app is blank' do
             app = submit_app(external_app)
@@ -58,17 +65,16 @@ module Cb
           end
 
           it 'converts the application to xml' do
-            expect(@mock_api).to receive(:cb_post).with(kind_of(String), body: external_app.to_xml).and_return(Hash.new)
+            expect(@mock_api).to receive(:cb_post).with(kind_of(String), body: external_app.to_xml).and_return({})
             submit_app(external_app)
           end
 
           it 'posts to the application external API endpoint' do
-            expect(@mock_api).to receive(:cb_post).with(Cb.configuration.uri_application_external, kind_of(Hash)).and_return(Hash.new)
+            expect(@mock_api).to receive(:cb_post).with(Cb.configuration.uri_application_external, kind_of(Hash)).and_return({})
             submit_app(external_app)
           end
         end
       end
     end
-
   end
 end

--- a/spec/cb/clients/application_spec.rb
+++ b/spec/cb/clients/application_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -69,7 +79,7 @@ module Cb
       end
 
       it 'sends #cb_post to api_client a uri with no did' do
-        expected_uri = "/cbapi/application/"
+        expected_uri = '/cbapi/application/'
         expect_any_instance_of(Cb::Utils::Api).to receive(http_calling_method).with(expected_uri, anything)
         subject
       end

--- a/spec/cb/clients/category_spec.rb
+++ b/spec/cb/clients/category_spec.rb
@@ -1,11 +1,20 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Clients::Category do
-    
     def stub_api_call_to_return(content_to_return)
-      stub_request(:get, uri_stem(Cb.configuration.uri_job_category_search)).
-        to_return(:body => content_to_return.to_json)
+      stub_request(:get, uri_stem(Cb.configuration.uri_job_category_search))
+        .to_return(body: content_to_return.to_json)
     end
 
     def assert_empty_array(api_client_result)
@@ -18,7 +27,7 @@ module Cb
       expect(api_client_result.size).to eq 1
       expect(api_client_result.first).to be_an_instance_of(Cb::Models::Category)
     end
-    
+
     context '.new' do
       it 'should create a new category api project' do
         category_api = Cb::Clients::Category.new
@@ -29,7 +38,7 @@ module Cb
     context '.search' do
       context 'when API response hash has all required fields' do
         before(:each) do
-          stub_api_call_to_return({ResponseCategories: {Categories: {Category: [{Code: 'doodad', Name: 'things', Language: 'wut'}]}}})
+          stub_api_call_to_return(ResponseCategories: { Categories: { Category: [{ Code: 'doodad', Name: 'things', Language: 'wut' }] } })
         end
 
         it 'returns an Array of category models' do
@@ -39,9 +48,8 @@ module Cb
 
       context 'when the API response has' do
         context 'missing fields' do
-
           context '\ResponseCategories' do
-            before(:each) { stub_api_call_to_return(Hash.new) }
+            before(:each) { stub_api_call_to_return({}) }
 
             it 'returns an empty Array' do
               assert_empty_array(Cb.category.search)
@@ -49,7 +57,7 @@ module Cb
           end
 
           context '\ResponseCategories\Categories' do
-            before(:each) { stub_api_call_to_return({ ResponseCategories: Hash.new })}
+            before(:each) { stub_api_call_to_return(ResponseCategories: {}) }
 
             it 'returns an empty Array' do
               assert_empty_array(Cb.category.search)
@@ -57,7 +65,7 @@ module Cb
           end
 
           context '\ResponseCategories\Categories\Category' do
-            before(:each) { stub_api_call_to_return({ ResponseCategories: { Categories: Hash.new } })}
+            before(:each) { stub_api_call_to_return(ResponseCategories: { Categories: {} }) }
 
             it 'raises a NoMethodError' do
               expect { Cb.category.search }.to raise_error NoMethodError
@@ -68,7 +76,7 @@ module Cb
         context 'fields that are the wrong type:' do
           context '\ResponseCategories\Categories\Category does not respond to #each' do
             before :each do
-              stub_api_call_to_return({ ResponseCategories: { Categories: { Category: String.new } } })
+              stub_api_call_to_return(ResponseCategories: { Categories: { Category: '' } })
             end
 
             it 'raises a NoMethodError when #each is attempted' do
@@ -77,14 +85,13 @@ module Cb
           end
         end
       end
-
     end # .search
 
     context '.search_by_host_site' do
       context 'when API response hash has all required fields' do
         context 'and \ResponseCategories\Categories\Category is an array' do
           before(:each) do
-            stub_api_call_to_return({ResponseCategories: {Categories: {Category: [{Code: 'doodad', Name: 'things', Language: 'wut'}]}}})
+            stub_api_call_to_return(ResponseCategories: { Categories: { Category: [{ Code: 'doodad', Name: 'things', Language: 'wut' }] } })
           end
 
           it 'returns an Array of category models' do
@@ -94,7 +101,7 @@ module Cb
 
         context 'and \ResponseCategories\Categories\Category is a hash (i.e. single category returned' do
           before(:each) do
-            stub_api_call_to_return({ResponseCategories: {Categories: {Category: {Code: 'doodad', Name: 'things', Language: 'wut'}}}})
+            stub_api_call_to_return(ResponseCategories: { Categories: { Category: { Code: 'doodad', Name: 'things', Language: 'wut' } } })
           end
 
           it 'returns an Array of category models' do
@@ -105,9 +112,8 @@ module Cb
 
       context 'when the API response has' do
         context 'missing fields' do
-
           context '\ResponseCategories' do
-            before(:each) { stub_api_call_to_return(Hash.new) }
+            before(:each) { stub_api_call_to_return({}) }
 
             it 'returns an empty Array' do
               assert_empty_array(Cb.category.search_by_host_site('WM'))
@@ -115,7 +121,7 @@ module Cb
           end
 
           context '\ResponseCategories\Categories' do
-            before(:each) { stub_api_call_to_return({ ResponseCategories: Hash.new }) }
+            before(:each) { stub_api_call_to_return(ResponseCategories: {}) }
 
             it 'returns an empty Array' do
               assert_empty_array(Cb.category.search_by_host_site('WM'))
@@ -123,7 +129,7 @@ module Cb
           end
 
           context '\ResponseCategories\Categories\Category' do
-            before(:each) { stub_api_call_to_return({ ResponseCategories: { Categories: Hash.new } })}
+            before(:each) { stub_api_call_to_return(ResponseCategories: { Categories: {} }) }
 
             it 'returns an empty array' do
               assert_empty_array(Cb.category.search_by_host_site('WM'))
@@ -134,7 +140,7 @@ module Cb
         context 'fields that are the wrong type:' do
           context '\ResponseCategories\Categories\Category is not an array or hash' do
             before :each do
-              stub_api_call_to_return({ ResponseCategories: { Categories: { Category: String.new } } })
+              stub_api_call_to_return(ResponseCategories: { Categories: { Category: '' } })
             end
 
             it 'returns an empty array' do
@@ -143,8 +149,6 @@ module Cb
           end
         end
       end
-
     end # .search_by_host_site
-
   end
 end

--- a/spec/cb/clients/company_spec.rb
+++ b/spec/cb/clients/company_spec.rb
@@ -1,19 +1,29 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Clients::Company do
     def stub_api_response_to_return(content)
-      stub_request(:get, uri_stem(Cb.configuration.uri_company_find)).
-        to_return(:body => content.to_json)
+      stub_request(:get, uri_stem(Cb.configuration.uri_company_find))
+        .to_return(body: content.to_json)
     end
 
     context '.find_by_did' do
       it 'pings the API with company DID and hostsite in the query string' do
         target_did = 'fake-did'
-        query_hash = { query: { CompanyDID: target_did, hostsite: Cb.configuration.host_site }}
+        query_hash = { query: { CompanyDID: target_did, hostsite: Cb.configuration.host_site } }
 
         cb_api_client = double(Cb::Utils::Api)
-        expect(cb_api_client).to receive(:cb_get).with(Cb.configuration.uri_company_find, query_hash).and_return(Hash.new)
+        expect(cb_api_client).to receive(:cb_get).with(Cb.configuration.uri_company_find, query_hash).and_return({})
         allow(cb_api_client).to receive(:append_api_responses)
         allow(Cb::Utils::Api).to receive(:new).and_return(cb_api_client)
 
@@ -23,13 +33,13 @@ module Cb
       context 'when the API response has all required nodes' do
         before(:each) do
           content = { Results: { CompanyProfileDetail: {
-            CompanyPhotos: { PhotoList: Array.new },
-            CompanyBulletinBoard: { bulletinboards: Hash.new },
-            Testimonials: { Testimonials: Array.new },
-            CompanyLinksCollection: { companylinks: Array.new },
-            MyContent: { MyContentTabs: Array.new },
-            InfoTabs: { InfoTabs: Array.new }
-          }}}
+            CompanyPhotos: { PhotoList: [] },
+            CompanyBulletinBoard: { bulletinboards: {} },
+            Testimonials: { Testimonials: [] },
+            CompanyLinksCollection: { companylinks: [] },
+            MyContent: { MyContentTabs: [] },
+            InfoTabs: { InfoTabs: [] }
+          } } }
           stub_api_response_to_return(content)
         end
 
@@ -40,7 +50,7 @@ module Cb
       end
 
       context 'when the API response does not contain the required fields:' do
-        before(:each) { stub_api_response_to_return(Hash.new) }
+        before(:each) { stub_api_response_to_return({}) }
 
         it '\Results missing, nil is returned' do
           expect(Cb::Clients::Company.find_by_did('fake-did')).to be_nil
@@ -57,7 +67,7 @@ module Cb
         context 'and the input string is empty' do
           it 'does not end up performing the company lookup' do
             expect(Cb::Clients::Company).not_to receive(:find_by_did)
-            Cb::Clients::Company.find_for(String.new)
+            Cb::Clients::Company.find_for('')
           end
         end
 
@@ -78,6 +88,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/clients/education_spec.rb
+++ b/spec/cb/clients/education_spec.rb
@@ -1,12 +1,20 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Clients::Education do
-
     context '#get_for' do
-
       def stub_api_to_return(content)
-        stub_request(:get, uri_stem(Cb.configuration.uri_education_code)).to_return(:body => content.to_json)
+        stub_request(:get, uri_stem(Cb.configuration.uri_education_code)).to_return(body: content.to_json)
       end
 
       context 'when things are working correctly' do
@@ -14,7 +22,7 @@ module Cb
 
         before :each do
           allow(mock_api).to receive(:append_api_responses)
-          allow(mock_api).to receive(:cb_get).and_return(Hash.new)
+          allow(mock_api).to receive(:cb_get).and_return({})
           allow(Cb::Utils::Api).to receive(:new).and_return(mock_api)
         end
 
@@ -26,7 +34,7 @@ module Cb
         it 'pings the education codes API endpoint with countrycode in the query string' do
           country_code = 'US'
           api_uri      = Cb.configuration.uri_education_code
-          query_hash   = { :query => { :countrycode => country_code}}
+          query_hash   = { query: { countrycode: country_code } }
 
           expect(mock_api).to receive(:cb_get).with(api_uri, query_hash)
           Cb::Clients::Education.get_for(country_code)
@@ -35,12 +43,12 @@ module Cb
 
       context 'when the API response has all required nodes' do
         before :each do
-          stub_api_to_return({ ResponseEducationCodes: { EducationCodes: { Education: [Hash.new]} } })
+          stub_api_to_return(ResponseEducationCodes: { EducationCodes: { Education: [{}] } })
         end
 
         it 'returns an array of education models' do
           models = Cb::Clients::Education.get_for('US')
-          expect(models).to       be_an_instance_of Array
+          expect(models).to be_an_instance_of Array
           expect(models.first).to be_an_instance_of Cb::Models::Education
         end
       end
@@ -52,7 +60,7 @@ module Cb
         end
 
         context '\ResponseEducationCodes' do
-          before(:each) { stub_api_to_return(Hash.new) }
+          before(:each) { stub_api_to_return({}) }
 
           it 'returns an empty array' do
             models = Cb::Clients::Education.get_for('US')
@@ -61,7 +69,7 @@ module Cb
         end
 
         context '\ResponseEducationCodes\EducationCodes' do
-          before(:each) { stub_api_to_return({ ResponseEducationCodes: Hash.new }) }
+          before(:each) { stub_api_to_return(ResponseEducationCodes: {}) }
 
           it 'returns an empty array' do
             models = Cb::Clients::Education.get_for('US')
@@ -70,7 +78,7 @@ module Cb
         end
 
         context '\ResponseEducationCodes\EducationCodes\Education' do
-          before(:each) { stub_api_to_return({ ResponseEducationCodes: { EducationCodes: Hash.new } }) }
+          before(:each) { stub_api_to_return(ResponseEducationCodes: { EducationCodes: {} }) }
 
           it 'returns an empty array' do
             models = Cb::Clients::Education.get_for('US')
@@ -79,14 +87,13 @@ module Cb
         end
 
         context 'has \ResponseEducationCodes\EducationCodes\Education, but no content in it' do
-          before(:each) { stub_api_to_return({ ResponseEducationCodes: { EducationCodes: { Education: nil } } }) }
+          before(:each) { stub_api_to_return(ResponseEducationCodes: { EducationCodes: { Education: nil } }) }
 
           it 'raises a NoMethodError when #each is attempted' do
             expect { Cb::Clients::Education.get_for('US') }.to raise_error NoMethodError
           end
         end
       end
-
     end
   end
 end

--- a/spec/cb/clients/employee_types_spec.rb
+++ b/spec/cb/clients/employee_types_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -6,7 +16,7 @@ module Cb
     let(:cb_api_client)     { (Cb.api_client.new) }
 
     before(:each) do
-      allow(cb_api_client).to receive(:cb_get).and_return({ 'bananas' => '4life' })
+      allow(cb_api_client).to receive(:cb_get).and_return('bananas' => '4life')
       allow(Cb.api_client).to receive(:new).and_return(cb_api_client)
       response = double(Responses::EmployeeTypes::Search)
       allow(response).to receive(:class).and_return Responses::EmployeeTypes::Search
@@ -40,7 +50,7 @@ module Cb
       it 'calls the employee types endpoint with hostsite query string' do
         endpoint_url = Cb.configuration.uri_employee_types
         hostsite = 'de'
-        query = { :query => { :CountryCode => hostsite } }
+        query = { query: { CountryCode: hostsite } }
         expect(cb_api_client).to receive(:cb_get).with(endpoint_url, query)
         client_under_test.search_by_hostsite(hostsite)
       end
@@ -49,6 +59,5 @@ module Cb
         returns_response_object(:search_by_hostsite, 'us')
       end
     end
-
   end
 end

--- a/spec/cb/clients/industry_spec.rb
+++ b/spec/cb/clients/industry_spec.rb
@@ -1,14 +1,23 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Clients::Industry do
     describe '#search' do
-
       before(:each) do
-        content = {:ResponseIndustryCodes => {:Errors=>'null', :CountryCode=>'US', :TimeResponseSent=>'4/1/2014 5:08:10 PM', :IndustryCodes=>{:IndustryCode=>[{:Code=>'IND067', :Name=>{'@language'=>'en','#text'=>'Accounting - Finance'}},{:Code =>'IND001', :Name => {'@language'=>'en','#text'=>'Advertising'}}]}}}
+        content = { ResponseIndustryCodes: { Errors: 'null', CountryCode: 'US', TimeResponseSent: '4/1/2014 5:08:10 PM', IndustryCodes: { IndustryCode: [{ Code: 'IND067', Name: { '@language' => 'en', '#text' => 'Accounting - Finance' } }, { Code: 'IND001', Name: { '@language' => 'en', '#text' => 'Advertising' } }] } } }
 
-        stub_request(:get, uri_stem(Cb.configuration.uri_job_industry_search)).
-            to_return(body: content.to_json)
+        stub_request(:get, uri_stem(Cb.configuration.uri_job_industry_search))
+          .to_return(body: content.to_json)
       end
 
       context 'search' do
@@ -17,8 +26,6 @@ module Cb
           expect(response.models.first).to be_an_instance_of(Cb::Models::Industry)
         end
       end
-
     end
-
   end
 end

--- a/spec/cb/clients/job_branding_spec.rb
+++ b/spec/cb/clients/job_branding_spec.rb
@@ -1,23 +1,31 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
-	describe Cb::Clients::JobBranding do
-
-		context '.find_by_id' do
+  describe Cb::Clients::JobBranding do
+    context '.find_by_id' do
       before :each do
-        content = { Branding: { Media: Hash.new, Sections: Array.new, Widgets: Hash.new, Styles: {
+        content = { Branding: { Media: {}, Sections: [], Widgets: {}, Styles: {
           Page: nil, JobDetails: { Container: nil, Content: nil, Headings: nil },
           CompanyInfo: { Buttons: nil, Container: nil, Content: nil, Headings: nil } } } }
 
-        stub_request(:get, uri_stem(Cb.configuration.uri_job_branding)).
-          to_return(:body => content.to_json)
+        stub_request(:get, uri_stem(Cb.configuration.uri_job_branding))
+          .to_return(body: content.to_json)
       end
 
-			it 'should return valid job branding schema' do
+      it 'should return valid job branding schema' do
         job_branding = Cb::Clients::JobBranding.find_by_id('fake-id')
         expect(job_branding).to be_an_instance_of Cb::Models::JobBranding
-			end
+      end
     end
-
-	end
+  end
 end

--- a/spec/cb/clients/job_spec.rb
+++ b/spec/cb/clients/job_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -5,14 +15,14 @@ module Cb
     describe '#search' do
       context 'when the search returns with no results' do
         before(:each) do
-          content = { ResponseJobSearch: { } }
+          content = { ResponseJobSearch: {} }
 
-          stub_request(:get, uri_stem(Cb.configuration.uri_job_search)).
-              to_return(body: content.to_json)
+          stub_request(:get, uri_stem(Cb.configuration.uri_job_search))
+            .to_return(body: content.to_json)
         end
 
         it 'returns an empty array' do
-          response = Cb.job.search(Hash.new)
+          response = Cb.job.search({})
           expect(response.model.jobs.count).to eq(0)
         end
       end
@@ -20,22 +30,22 @@ module Cb
       context 'when the search returns a location conflict' do
         before(:each) do
           content = { ResponseJobSearch: {
-                      'Results' => {
-                          'LocationConflict' => {
-                            'Location' => 'Atlantica Aeneas Hotel, CY',
-                            'Location' => 'Atlantica Miramare Beach, CY',
-                            'Location' => 'Atlantica Sungarden Beach Hotel, CY'
-                          }
-                        }
-                      }
+            'Results' => {
+              'LocationConflict' => {
+                'Location' => 'Atlantica Aeneas Hotel, CY',
+                'Location' => 'Atlantica Miramare Beach, CY',
+                'Location' => 'Atlantica Sungarden Beach Hotel, CY'
+              }
+            }
+          }
                     }
 
-          stub_request(:get, uri_stem(Cb.configuration.uri_job_search)).
-              to_return(body: content.to_json)
+          stub_request(:get, uri_stem(Cb.configuration.uri_job_search))
+            .to_return(body: content.to_json)
         end
 
         it 'returns an empty array' do
-          response = Cb.job.search(Hash.new)
+          response = Cb.job.search({})
           expect(response.model.jobs.count).to eq(0)
         end
       end
@@ -43,15 +53,15 @@ module Cb
       context 'when the search returns with results' do
         before(:each) do
           content = { ResponseJobSearch: {
-              SearchMetaData: { SearchLocations: { SearchLocation: ['tahiti'] } },
-              Results: { JobSearchResult: [Hash.new] } } }
+            SearchMetaData: { SearchLocations: { SearchLocation: ['tahiti'] } },
+            Results: { JobSearchResult: [{}] } } }
 
-          stub_request(:get, uri_stem(Cb.configuration.uri_job_search)).
-              to_return(body: content.to_json)
+          stub_request(:get, uri_stem(Cb.configuration.uri_job_search))
+            .to_return(body: content.to_json)
         end
 
         it 'returns an array of job models' do
-          response = Cb.job.search(Hash.new)
+          response = Cb.job.search({})
           expect(response.model.jobs[0].is_a?(Cb::Models::Job)).to eq(true)
         end
       end
@@ -59,27 +69,26 @@ module Cb
       context 'When the search returns only one result' do
         before(:each) do
           content = {
-              ResponseJobSearch: {
-                  SearchMetaData: { SearchLocations: { SearchLocation: ['tahiti'] } },
-                  Results: { JobSearchResult: {} }
-              }
+            ResponseJobSearch: {
+              SearchMetaData: { SearchLocations: { SearchLocation: ['tahiti'] } },
+              Results: { JobSearchResult: {} }
+            }
           }
-          stub_request(:get, uri_stem(Cb.configuration.uri_job_search)).to_return(:body => content.to_json)
+          stub_request(:get, uri_stem(Cb.configuration.uri_job_search)).to_return(body: content.to_json)
         end
 
         it 'returns an array of job models' do
-          search = Cb.job.search(Hash.new)
+          search = Cb.job.search({})
           expect(search.model.jobs[0]).to be_a Cb::Models::Job
         end
       end
 
-
       context 'When the search returns with collapsed results' do
-        let(:search) {Cb.job.search(Hash.new)}
-        let(:content) {JSON.parse(File.read('spec/support/response_stubs/collapsed_search.json'))}
+        let(:search) { Cb.job.search({}) }
+        let(:content) { JSON.parse(File.read('spec/support/response_stubs/collapsed_search.json')) }
 
         before do
-          stub_request(:get, uri_stem(Cb.configuration.uri_job_search)).to_return(:body => content.to_json)
+          stub_request(:get, uri_stem(Cb.configuration.uri_job_search)).to_return(body: content.to_json)
         end
 
         it { expect(search.model).to be_a Cb::Models::CollapsedJobResults }
@@ -87,16 +96,15 @@ module Cb
         it { expect(search.model.grouped_jobs[0].grouping_value).to eq '123321' }
         it { expect(search.model.grouped_jobs[0].job_count).to eq 1 }
         it { expect(search.model.grouped_jobs[0].job).to eq search.model.grouped_jobs[0].job_description  }
-
       end
 
       context 'When the search returns with 1 collapsed result and CB Serialization' do
-        let(:search) {Cb.job.search(Hash.new)}
-        let(:content) {JSON.parse(File.read('spec/support/response_stubs/single_result_in_collapsed_search_with_CB_serialization.json'))}
-        let(:grouped_jobs) { search.model.grouped_jobs[0]}
+        let(:search) { Cb.job.search({}) }
+        let(:content) { JSON.parse(File.read('spec/support/response_stubs/single_result_in_collapsed_search_with_CB_serialization.json')) }
+        let(:grouped_jobs) { search.model.grouped_jobs[0] }
 
         before do
-          stub_request(:get, uri_stem(Cb.configuration.uri_job_search)).to_return(:body => content.to_json)
+          stub_request(:get, uri_stem(Cb.configuration.uri_job_search)).to_return(body: content.to_json)
         end
 
         it { expect(search.model).to be_a Cb::Models::CollapsedJobResults }
@@ -104,15 +112,13 @@ module Cb
         it { expect(grouped_jobs.grouping_value).to eq '123321' }
         it { expect(grouped_jobs.job_count).to eq 1 }
         it { expect(grouped_jobs.job).to eq grouped_jobs.job_description  }
-
       end
-
     end
 
     describe '#find_by_criteria' do
       before :each do
-        stub_request(:get, uri_stem(Cb.configuration.uri_job_find)).
-            to_return(:body => { ResponseJob: { Job: Hash.new } }.to_json)
+        stub_request(:get, uri_stem(Cb.configuration.uri_job_find))
+          .to_return(body: { ResponseJob: { Job: {} } }.to_json)
       end
 
       let(:criteria) { Cb::Criteria::Job::Details.new }
@@ -147,6 +153,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/clients/recommendation_spec.rb
+++ b/spec/cb/clients/recommendation_spec.rb
@@ -1,13 +1,23 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 require 'support/mocks/oauth_token'
 
 module Cb
   describe Cb::Clients::Recommendation do
-    let(:api_job_result_collection) { [Hash.new] }
+    let(:api_job_result_collection) { [{}] }
 
     shared_context :for_job do
       it 'should get recommendations for a job using a hash' do
-        recs = Cb.recommendation.for_job({ :JobDID => 'fake-did' })
+        recs = Cb.recommendation.for_job(JobDID: 'fake-did')
 
         expect(recs[0].is_a?(Cb::Models::Job)).to eq(true)
         expect(recs.count).to be > 0
@@ -25,15 +35,15 @@ module Cb
 
     context '.for_job' do
       before :each do
-        stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_job)).
-          to_return(:body => { ResponseRecommendJob: { Request: Hash.new, RecommendJobResults: { RecommendJobResult: api_job_result_collection } } }.to_json)
+        stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_job))
+          .to_return(body: { ResponseRecommendJob: { Request: {}, RecommendJobResults: { RecommendJobResult: api_job_result_collection } } }.to_json)
       end
 
       include_context :for_job
 
       context 'when the api returns one job' do
         let(:api_job_result_collection) { Hash.new }
-        
+
         include_context :for_job
       end
     end
@@ -41,7 +51,7 @@ module Cb
     shared_context :for_user do
       it 'should get recommendations for a user using a hash' do
         test_user_external_id = 'XRHS30G60RWSQ5P1S8RG'
-        recs = Cb.recommendation.for_user({ :ExternalID => test_user_external_id })
+        recs = Cb.recommendation.for_user(ExternalID: test_user_external_id)
 
         expect(recs.count).to be > 0
         expect(recs[0].is_a?(Cb::Models::Job)).to eq(true)
@@ -60,18 +70,17 @@ module Cb
 
     context '.for_user' do
       before :each do
-        stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_user)).
-          to_return(:body => { ResponseRecommendUser: { Request: Hash.new, RecommendJobResults: { RecommendJobResult: api_job_result_collection } } }.to_json)
+        stub_request(:get, uri_stem(Cb.configuration.uri_recommendation_for_user))
+          .to_return(body: { ResponseRecommendUser: { Request: {}, RecommendJobResults: { RecommendJobResult: api_job_result_collection } } }.to_json)
       end
 
       include_context :for_user
 
       context 'when the api returns one job' do
         let(:api_job_result_collection) { Hash.new }
-        
+
         include_context :for_user
       end
     end
-
   end
 end

--- a/spec/cb/clients/saved_search_spec.rb
+++ b/spec/cb/clients/saved_search_spec.rb
@@ -1,9 +1,18 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 require 'support/mocks/saved_search'
 
 module Cb
   describe Cb::Clients::SavedSearch do
-
     context '.new' do
       it 'should create a new saved job search api object' do
         saved_search_request = Cb::Clients::SavedSearch.new
@@ -13,17 +22,17 @@ module Cb
 
     context '.create' do
       before :each do
-        stub_request(:post, uri_stem(Cb.configuration.uri_saved_search_create)).
-          with(:body => anything).
-          to_return(:body => { SavedJobSearch: { Errors: nil, SavedSearch: Hash.new } }.to_json)
+        stub_request(:post, uri_stem(Cb.configuration.uri_saved_search_create))
+          .with(body: anything)
+          .to_return(body: { SavedJobSearch: { Errors: nil, SavedSearch: {} } }.to_json)
       end
 
       it 'should return a saved search retrieve response' do
         email_frequency = 'None'
         search_name = 'Fake Job Search 1'
-        model = Models::SavedSearch.new({'DeveloperKey' => Cb.configuration.dev_key, 'IsDailyEmail' => email_frequency,
-                                         'ExternalUserID' => @external_user_id, 'SearchName' => search_name,
-                                         'HostSite' => @host_site})
+        model = Models::SavedSearch.new('DeveloperKey' => Cb.configuration.dev_key, 'IsDailyEmail' => email_frequency,
+                                        'ExternalUserID' => @external_user_id, 'SearchName' => search_name,
+                                        'HostSite' => @host_site)
 
         expect(Cb.saved_search.new.create(model).class).to eq Responses::SavedSearch::Singular
       end
@@ -32,10 +41,10 @@ module Cb
     context '.update' do
       context 'with host_site passed in the request header' do
         before do
-          stub_request(:put, uri_stem(Cb.configuration.uri_saved_search_update)).
-            with(:body => anything,
-                 :headers => {"developerkey" => Cb.configuration.dev_key, "Content-Type" => "application/json", "HostSite" => 'GR' }).
-            to_return(:body => { Errors: nil, Results: [{ SavedSearchParameters: Hash.new }] }.to_json)
+          stub_request(:put, uri_stem(Cb.configuration.uri_saved_search_update))
+            .with(body: anything,
+                  headers: { 'developerkey' => Cb.configuration.dev_key, 'Content-Type' => 'application/json', 'HostSite' => 'GR' })
+            .to_return(body: { Errors: nil, Results: [{ SavedSearchParameters: {} }] }.to_json)
         end
 
         it 'should update the saved search created in this test' do
@@ -43,9 +52,9 @@ module Cb
           oauth = '123412341234'
           email_frequency = 'None'
           search_name = 'Fake Job Search Update'
-          model = Models::SavedSearch.new({'IsDailyEmail' => email_frequency,
-                                           'DID' => external_id, 'SearchName' => search_name,
-                                           'HostSite' => 'GR', 'userOAuthToken' => oauth})
+          model = Models::SavedSearch.new('IsDailyEmail' => email_frequency,
+                                          'DID' => external_id, 'SearchName' => search_name,
+                                          'HostSite' => 'GR', 'userOAuthToken' => oauth)
 
           response = Cb.saved_search.new.update(model)
           expect(response.model.class).to eq Models::SavedSearch
@@ -54,10 +63,10 @@ module Cb
 
       context 'with no host_site passed in the request header' do
         before do
-          stub_request(:put, uri_stem(Cb.configuration.uri_saved_search_update)).
-              with(:body => anything,
-                   :headers => {"developerkey" => Cb.configuration.dev_key, "Content-Type" => "application/json", "HostSite" => 'US' }).
-              to_return(:body => { Errors: nil, Results: [{ SavedSearchParameters: Hash.new }] }.to_json)
+          stub_request(:put, uri_stem(Cb.configuration.uri_saved_search_update))
+            .with(body: anything,
+                  headers: { 'developerkey' => Cb.configuration.dev_key, 'Content-Type' => 'application/json', 'HostSite' => 'US' })
+            .to_return(body: { Errors: nil, Results: [{ SavedSearchParameters: {} }] }.to_json)
         end
 
         it 'should update the saved search created in this test' do
@@ -65,10 +74,9 @@ module Cb
           oauth = '123412341234'
           email_frequency = 'None'
           search_name = 'update_headers(saved_search.host_site)Fake Job Search Update'
-          model = Models::SavedSearch.new({'IsDailyEmail' => email_frequency,
-                                           'DID' => external_id, 'SearchName' => search_name,
-                                           'HostSite' => nil, 'userOAuthToken' => oauth})
-
+          model = Models::SavedSearch.new('IsDailyEmail' => email_frequency,
+                                          'DID' => external_id, 'SearchName' => search_name,
+                                          'HostSite' => nil, 'userOAuthToken' => oauth)
 
           response = Cb.saved_search.new.update(model)
           expect(response.model.class).to eq Models::SavedSearch
@@ -78,8 +86,10 @@ module Cb
 
     context '.list' do
       context 'with results' do
-        before { stub_request(:get, uri_stem(Cb.configuration.uri_saved_search_list)).
-                  to_return(:body => Mocks::SavedSearch.list.to_json) }
+        before do
+          stub_request(:get, uri_stem(Cb.configuration.uri_saved_search_list))
+            .to_return(body: Mocks::SavedSearch.list.to_json)
+        end
 
         it 'should return an array of saved searches' do
           user_saved_search = Cb.saved_search.new.list(@user_oauth_token, 'WR')
@@ -90,8 +100,10 @@ module Cb
       end
 
       context 'with no results' do
-        before { stub_request(:get, uri_stem(Cb.configuration.uri_saved_search_list)).
-            to_return(:body => Mocks::SavedSearch.empty_list.to_json) }
+        before do
+          stub_request(:get, uri_stem(Cb.configuration.uri_saved_search_list))
+            .to_return(body: Mocks::SavedSearch.empty_list.to_json)
+        end
 
         it 'should return an array of saved searches' do
           user_saved_search = Cb.saved_search.new.list(@user_oauth_token, 'WR')
@@ -103,25 +115,24 @@ module Cb
 
     context '.retrieve' do
       before :each do
-        stub_request(:get, uri_stem(Cb.configuration.uri_saved_search_retrieve.gsub(':did', 'xid'))).
-          to_return(:body => {
-            "TotalResults"=>1,
-            "ReturnedResults"=>1,
-            "Results"=>
-            [{"DID"=>"OMG DIDs",
-              "SearchName"=>"Why can't I find a jerb?",
-              "HostSite"=>"Merkah",
-              "SiteID"=>"",
-              "Cobrand"=>"",
-              "IsDailyEmail"=>"maybe",
-              "EmailDeliveryDay"=>"YESTERDAY",
-              "JobSearchUrl"=>"blerg.com",
-              "SavedSearchParameters"=>{
-                  "Any"=>"No"}
+        stub_request(:get, uri_stem(Cb.configuration.uri_saved_search_retrieve.gsub(':did', 'xid')))
+          .to_return(body: {
+            'TotalResults' => 1,
+            'ReturnedResults' => 1,
+            'Results' =>             [{ 'DID' => 'OMG DIDs',
+                                        'SearchName' => "Why can't I find a jerb?",
+                                        'HostSite' => 'Merkah',
+                                        'SiteID' => '',
+                                        'Cobrand' => '',
+                                        'IsDailyEmail' => 'maybe',
+                                        'EmailDeliveryDay' => 'YESTERDAY',
+                                        'JobSearchUrl' => 'blerg.com',
+                                        'SavedSearchParameters' => {
+                                          'Any' => 'No' }
              }],
-            "Errors"=>[],
-            "Timestamp"=>"2014-03-25T15:29:27.8361791-04:00",
-            "Status"=>"YEY"}.to_json)
+            'Errors' => [],
+            'Timestamp' => '2014-03-25T15:29:27.8361791-04:00',
+            'Status' => 'YEY' }.to_json)
       end
 
       it 'should return a saved search model' do
@@ -132,16 +143,15 @@ module Cb
 
     context '.delete' do
       before :each do
-        stub_request(:delete, "https://api.careerbuilder.com/cbapi/savedsearches/xid?UserOAuthToken=oauth&developerkey=mydevkey&outputjson=true").
-          with(:headers => {'Accept-Encoding'=>'deflate, gzip', 'Developerkey'=>'mydevkey', 'Hostsite'=>'host site'}).
-          to_return(:body => { Errors: nil, Status: 'Success' }.to_json)
+        stub_request(:delete, 'https://api.careerbuilder.com/cbapi/savedsearches/xid?UserOAuthToken=oauth&developerkey=mydevkey&outputjson=true')
+          .with(headers: { 'Accept-Encoding' => 'deflate, gzip', 'Developerkey' => 'mydevkey', 'Hostsite' => 'host site' })
+          .to_return(body: { Errors: nil, Status: 'Success' }.to_json)
       end
 
       it 'should delete a saved search without error' do
-        hash = {did: 'xid', user_oauth_token: "oauth", host_site: "host site"}
+        hash = { did: 'xid', user_oauth_token: 'oauth', host_site: 'host site' }
         Cb.saved_search.new.delete(hash)
       end
     end
-
   end
 end

--- a/spec/cb/clients/saved_search_spec.rb
+++ b/spec/cb/clients/saved_search_spec.rb
@@ -119,16 +119,17 @@ module Cb
           .to_return(body: {
             'TotalResults' => 1,
             'ReturnedResults' => 1,
-            'Results' =>             [{ 'DID' => 'OMG DIDs',
-                                        'SearchName' => "Why can't I find a jerb?",
-                                        'HostSite' => 'Merkah',
-                                        'SiteID' => '',
-                                        'Cobrand' => '',
-                                        'IsDailyEmail' => 'maybe',
-                                        'EmailDeliveryDay' => 'YESTERDAY',
-                                        'JobSearchUrl' => 'blerg.com',
-                                        'SavedSearchParameters' => {
-                                          'Any' => 'No' }
+            'Results' =>
+            [{ 'DID' => 'OMG DIDs',
+                'SearchName' => "Why can't I find a jerb?",
+                'HostSite' => 'Merkah',
+                'SiteID' => '',
+                'Cobrand' => '',
+                'IsDailyEmail' => 'maybe',
+                'EmailDeliveryDay' => 'YESTERDAY',
+                'JobSearchUrl' => 'blerg.com',
+                'SavedSearchParameters' => {
+                  'Any' => 'No' }
              }],
             'Errors' => [],
             'Timestamp' => '2014-03-25T15:29:27.8361791-04:00',

--- a/spec/cb/clients/talent_network_spec.rb
+++ b/spec/cb/clients/talent_network_spec.rb
@@ -1,15 +1,25 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Clients::TalentNetwork do
     context '.tn_job_information' do
       before :each do
-        stub_request(:get, uri_stem(Cb.configuration.uri_tn_job_info)).
-          to_return(:body => { Response: Hash.new }.to_json)
+        stub_request(:get, uri_stem(Cb.configuration.uri_tn_job_info))
+          .to_return(body: { Response: {} }.to_json)
       end
 
-      it 'should retrieve the tn job information with a good job DID' do 
-        valid_did = "JHL5ZF68B66TBD63Z62"
+      it 'should retrieve the tn job information with a good job DID' do
+        valid_did = 'JHL5ZF68B66TBD63Z62'
         job_info = Cb.talent_network.tn_job_information(valid_did)
         expect(job_info.class).to be == Cb::Models::TalentNetwork::JobInfo
         expect(job_info.api_error).to eq(false)
@@ -18,11 +28,11 @@ module Cb
 
     context '.join_form_questions' do
       before :each do
-        stub_request(:get, uri_stem(Cb.configuration.uri_tn_join_questions)).
-          to_return(:body => { JoinQuestions: [Hash.new] }.to_json)
+        stub_request(:get, uri_stem(Cb.configuration.uri_tn_join_questions))
+          .to_return(body: { JoinQuestions: [{}] }.to_json)
       end
 
-      it 'should retrieve the form questions given a valid tn DID' do 
+      it 'should retrieve the form questions given a valid tn DID' do
         tn_did = 'CB000000000000000001'
         join_form = Cb.talent_network.join_form_questions(tn_did)
         expect(join_form.join_form_questions.size).to be > 0
@@ -32,8 +42,8 @@ module Cb
 
     context '.join_form_branding' do
       before :each do
-        stub_request(:get, uri_stem(Cb.configuration.uri_tn_join_form_branding)).
-          to_return(:body => { Branding: Hash.new }.to_json)
+        stub_request(:get, uri_stem(Cb.configuration.uri_tn_join_form_branding))
+          .to_return(body: { Branding: {} }.to_json)
       end
 
       it 'should retrieve branding information for a valid tn DID' do
@@ -46,14 +56,14 @@ module Cb
 
     context '.join_form_geography' do
       before :each do
-        stub_request(:get, uri_stem(Cb.configuration.uri_tn_join_form_geo)).
-          to_return(:body => { Countries: Hash.new, States: Hash.new }.to_json)
+        stub_request(:get, uri_stem(Cb.configuration.uri_tn_join_form_geo))
+          .to_return(body: { Countries: {}, States: {} }.to_json)
       end
 
-      it 'should retrieve the geo dropdown list info for join form questions' do 
+      it 'should retrieve the geo dropdown list info for join form questions' do
         join_form_geo = Cb.talent_network.join_form_geography
         expect(join_form_geo.nil?).to eq(false)
-      
+
         join_form_geo.countries.geo_hash.length > 0
         join_form_geo.states.geo_hash.length > 0
         expect(join_form_geo.api_error).to eq(false)
@@ -62,27 +72,26 @@ module Cb
 
     context '.member_create' do
       before :each do
-        stub_request(:post, uri_stem(Cb.configuration.uri_tn_member_create)).
-          with(:body => anything).
-          to_return(:body => { Errors: Array.new }.to_json)
+        stub_request(:post, uri_stem(Cb.configuration.uri_tn_member_create))
+          .with(body: anything)
+          .to_return(body: { Errors: [] }.to_json)
       end
 
       it 'should successfully create a tn member' do
-        args1 = Hash.new
+        args1 = {}
         args1['TNDID'] = 'CB000000000000000001'
-        args1['JoinValues'] = ["MxDOTalentNetworkMemberInfo_EmailAddress", "niche_11_test@test.com",
-                              "MxDOTalentNetworkMemberInfo_FirstName","Niche1",
-                                "MxDOTalentNetworkMemberInfo_LastName", "Tester1",
-                                  "MxDOTalentNetworkMemberInfo_ZipCode","30092",
-                                  "JQJBF32R79L0SH6H3K2D","Software Enginner",
-                                  "ddlCountries","us"]
+        args1['JoinValues'] = ['MxDOTalentNetworkMemberInfo_EmailAddress', 'niche_11_test@test.com',
+                               'MxDOTalentNetworkMemberInfo_FirstName', 'Niche1',
+                               'MxDOTalentNetworkMemberInfo_LastName', 'Tester1',
+                               'MxDOTalentNetworkMemberInfo_ZipCode', '30092',
+                               'JQJBF32R79L0SH6H3K2D', 'Software Enginner',
+                               'ddlCountries', 'us']
 
         member = Cb.talent_network.member_create(args1)
-        expect(member.cb_response.errors.first).not_to eq("EmailInUse")
+        expect(member.cb_response.errors.first).not_to eq('EmailInUse')
         expect(member.nil?).not_to eq(true)
         expect(member.api_error).to eq(false)
       end
-
     end
   end
 end

--- a/spec/cb/clients/user_spec.rb
+++ b/spec/cb/clients/user_spec.rb
@@ -1,12 +1,21 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Clients::User do
-
     describe '#temporary_password' do
       before do
-        stub_request(:get, uri_stem(Cb.configuration.uri_user_temp_password)).
-          to_return(:body => { Errors: [], TemporaryPassword: 'hotdogs!' }.to_json)
+        stub_request(:get, uri_stem(Cb.configuration.uri_user_temp_password))
+          .to_return(body: { Errors: [], TemporaryPassword: 'hotdogs!' }.to_json)
       end
 
       it 'requires a single param (external id)' do
@@ -120,15 +129,13 @@ module Cb
           end
         end
       end
-
     end
-
 
     context '.retrieve' do
       before :each do
-        stub_request(:post, uri_stem(Cb.configuration.uri_user_retrieve)).
-          with(:body => anything).
-          to_return(:body => { ResponseUserInfo: { Errors: nil, Status: 'Success (Test)', UserInfo: Hash.new } }.to_json)
+        stub_request(:post, uri_stem(Cb.configuration.uri_user_retrieve))
+          .with(body: anything)
+          .to_return(body: { ResponseUserInfo: { Errors: nil, Status: 'Success (Test)', UserInfo: {} } }.to_json)
       end
 
       it 'should retrieve a user' do
@@ -142,12 +149,12 @@ module Cb
 
     context '.delete' do
       before :each do
-        stub_request(:post, uri_stem(Cb.configuration.uri_user_delete)).
-          with(:body => anything).
-          to_return(:body => { ResponseUserDelete: { Request: {}, Status: 'Success (Test)' } }.to_json)
+        stub_request(:post, uri_stem(Cb.configuration.uri_user_delete))
+          .with(body: anything)
+          .to_return(body: { ResponseUserDelete: { Request: {}, Status: 'Success (Test)' } }.to_json)
       end
 
-      it 'should delete a user', :vcr => { :cassette_name => 'user/delete/success' } do
+      it 'should delete a user', vcr: { cassette_name: 'user/delete/success' } do
         result = Cb.user.delete(Cb::Criteria::User::Delete.new(external_id: 'xid', password: 'passwort'))
 
         expect(result).to be_an_instance_of Cb::Responses::User::Delete
@@ -157,7 +164,7 @@ module Cb
     end
 
     describe '#retrieve' do
-      let(:api_response) do { 'ResponseUserInfo' => { 'UserInfo' => 'yeehaw' } } end
+      let(:api_response) { { 'ResponseUserInfo' => { 'UserInfo' => 'yeehaw' } } }
       it 'builds xml correctly' do
         body = <<-eos
             <Request>
@@ -174,7 +181,7 @@ module Cb
 
     describe '#delete' do
       before { allow(Cb::Responses::User::Delete).to receive(:new).and_return('fake response') }
-      let(:api_response) do { 'ResponseUserDelete' => 'yeehaw' } end
+      let(:api_response) { { 'ResponseUserDelete' => 'yeehaw' } }
 
       it 'builds xml correctly' do
         body = <<-eos
@@ -191,17 +198,16 @@ eos
       end
     end
 
-    describe  '#change_pwd' do
+    describe '#change_pwd' do
       context 'When an user makes a change password request' do
-        let(:user_info_change_password) {
-          Cb::Criteria::User::ChangePassword.new({
-                                                   external_id: '123TEST',
-                                                   old_password: 'MyPassWord123',
-                                                   new_password: 'MyNewPassword123',
-                                                   test: 'false'
-                                                 }) }
-        let(:api_return_fail) do { 'ResponseUserChangePW' => { 'Request' => { 'ExternalID' => 'EXT12345', 'Errors' => 'An error occurred' }, 'Status' => 'Fail' } } end
-        let(:api_return_success) do { 'ResponseUserChangePW' => { 'Request' => { 'ExternalID' => 'EXT12345', 'Errors' => '' }, 'Status' => 'Success' } } end
+        let(:user_info_change_password) do
+          Cb::Criteria::User::ChangePassword.new(external_id: '123TEST',
+                                                 old_password: 'MyPassWord123',
+                                                 new_password: 'MyNewPassword123',
+                                                 test: 'false')
+        end
+        let(:api_return_fail) { { 'ResponseUserChangePW' => { 'Request' => { 'ExternalID' => 'EXT12345', 'Errors' => 'An error occurred' }, 'Status' => 'Fail' } } }
+        let(:api_return_success) { { 'ResponseUserChangePW' => { 'Request' => { 'ExternalID' => 'EXT12345', 'Errors' => '' }, 'Status' => 'Success' } } }
 
         it 'should return a proper response when the change password call fails' do
           allow_any_instance_of(Cb::Utils::Api).to receive(:cb_post).and_return(api_return_fail)

--- a/spec/cb/config_spec.rb
+++ b/spec/cb/config_spec.rb
@@ -1,13 +1,23 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Config do
     context '.to_hash' do
       it 'should return a hash' do
-      	config = Cb.configuration
+        config = Cb.configuration
 
-      	expect(config.is_a?(Cb::Config)).to eq(true)
-      	expect(config.to_hash.is_a?(Hash)).to eq(true)
+        expect(config.is_a?(Cb::Config)).to eq(true)
+        expect(config.to_hash.is_a?(Hash)).to eq(true)
       end
     end
     context 'defaults' do

--- a/spec/cb/convenience_spec.rb
+++ b/spec/cb/convenience_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Convenience::ClassMethods do
-
     def expect_method_to_return_class(method, klass)
       returned_convenience_class = Cb.send(method)
       expect(returned_convenience_class).to be klass
@@ -109,5 +118,4 @@ module Cb
       end
     end
   end
-
 end

--- a/spec/cb/criteria/application/create_spec.rb
+++ b/spec/cb/criteria/application/create_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Criteria::Application
   describe Create do
-
     describe '#to_json' do
       context 'when creating real resources' do
         it 'converts the criteria to json' do
@@ -19,45 +28,45 @@ module Cb::Criteria::Application
       end
     end
 
-    let(:criteria) {
+    let(:criteria) do
       Create.new
-      .job_did('job_123')
-      .is_submitted(false)
-      .external_user_id('external_user_123')
-      .vid('hamburger_avalanche')
-      .bid('bid_123')
-      .sid('sid_123')
-      .site_id('site_123')
-      .ipath_id('ipath_123')
-      .tn_did('tn_123')
-      .host_site('US')
-      .resume(resume)
-      .cover_letter(cover_letter)
-      .responses(responses)
-    }
-    let(:resume) {
+        .job_did('job_123')
+        .is_submitted(false)
+        .external_user_id('external_user_123')
+        .vid('hamburger_avalanche')
+        .bid('bid_123')
+        .sid('sid_123')
+        .site_id('site_123')
+        .ipath_id('ipath_123')
+        .tn_did('tn_123')
+        .host_site('US')
+        .resume(resume)
+        .cover_letter(cover_letter)
+        .responses(responses)
+    end
+    let(:resume) do
       Resume.new
-      .external_resume_id('external_resume_123')
-      .resume_file_name('my resume')
-      .resume_data(1010101010101)
-      .resume_extension('pdf')
-      .resume_title('Nurse')
-    }
-    let(:cover_letter) {
+        .external_resume_id('external_resume_123')
+        .resume_file_name('my resume')
+        .resume_data(1_010_101_010_101)
+        .resume_extension('pdf')
+        .resume_title('Nurse')
+    end
+    let(:cover_letter) do
       CoverLetter.new
-      .cover_letter_id('cover_letter_123')
-      .cover_letter_text('yeah hi')
-      .cover_letter_title('best nurse ever')
-    }
-    let(:responses) {
+        .cover_letter_id('cover_letter_123')
+        .cover_letter_text('yeah hi')
+        .cover_letter_title('best nurse ever')
+    end
+    let(:responses) do
       [
         Response.new
-        .question_id('question_123')
-        .response_text('Yes please')
+          .question_id('question_123')
+          .response_text('Yes please')
       ]
-    }
+    end
 
-    let(:expected_json) {
+    let(:expected_json) do
       {
         JobDID: criteria.job_did,
         IsSubmitted: criteria.is_submitted,
@@ -85,8 +94,8 @@ module Cb::Criteria::Application
           ResponseText: responses[0].response_text
         }]
       }.to_json
-    }
-    let(:expected_json_with_test) {
+    end
+    let(:expected_json_with_test) do
       {
         JobDID: criteria.job_did,
         IsSubmitted: criteria.is_submitted,
@@ -115,7 +124,6 @@ module Cb::Criteria::Application
         }],
         Test: true
       }.to_json
-    }
-
+    end
   end
 end

--- a/spec/cb/criteria/application/get_spec.rb
+++ b/spec/cb/criteria/application/get_spec.rb
@@ -1,16 +1,25 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Criteria
   describe Application::Get do
-    let(:criteria) {
+    let(:criteria) do
       Application::Get.new.application_did('ja123')
-    }
+    end
 
     describe '#application_did' do
       it 'returns application did' do
         expect(criteria.application_did).to eq 'ja123'
       end
     end
-
   end
 end

--- a/spec/cb/criteria/application/update_spec.rb
+++ b/spec/cb/criteria/application/update_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Criteria::Application
   describe Update do
-
     describe '#to_json' do
       context 'when updating real resources' do
         it 'converts the criteria to json' do
@@ -19,45 +28,45 @@ module Cb::Criteria::Application
       end
     end
 
-    let(:criteria) {
+    let(:criteria) do
       Update.new
-      .application_did('ja_123')
-      .job_did('job_123')
-      .is_submitted(true)
-      .external_user_id('external_user_123')
-      .bid('bid_123')
-      .vid('hotdog_tsunami')
-      .sid('sid_123')
-      .site_id('site_123')
-      .ipath_id('ipath_123')
-      .tn_did('tn_123')
-      .resume(resume)
-      .cover_letter(cover_letter)
-      .responses(responses)
-    }
-    let(:resume) {
+        .application_did('ja_123')
+        .job_did('job_123')
+        .is_submitted(true)
+        .external_user_id('external_user_123')
+        .bid('bid_123')
+        .vid('hotdog_tsunami')
+        .sid('sid_123')
+        .site_id('site_123')
+        .ipath_id('ipath_123')
+        .tn_did('tn_123')
+        .resume(resume)
+        .cover_letter(cover_letter)
+        .responses(responses)
+    end
+    let(:resume) do
       Resume.new
-      .external_resume_id('external_resume_123')
-      .resume_file_name('my resume')
-      .resume_data(1010101010101)
-      .resume_extension('pdf')
-      .resume_title('Nurse')
-    }
-    let(:cover_letter) {
+        .external_resume_id('external_resume_123')
+        .resume_file_name('my resume')
+        .resume_data(1_010_101_010_101)
+        .resume_extension('pdf')
+        .resume_title('Nurse')
+    end
+    let(:cover_letter) do
       CoverLetter.new
-      .cover_letter_id('cover_letter_123')
-      .cover_letter_text('yeah hi')
-      .cover_letter_title('best nurse ever')
-    }
-    let(:responses) {
+        .cover_letter_id('cover_letter_123')
+        .cover_letter_text('yeah hi')
+        .cover_letter_title('best nurse ever')
+    end
+    let(:responses) do
       [
         Response.new
-        .question_id('question_123')
-        .response_text('Yes please')
+          .question_id('question_123')
+          .response_text('Yes please')
       ]
-    }
+    end
 
-    let(:expected_json) {
+    let(:expected_json) do
       {
         ApplicationDID: criteria.application_did,
         JobDID: criteria.job_did,
@@ -86,8 +95,8 @@ module Cb::Criteria::Application
           ResponseText: responses[0].response_text
         }]
       }.to_json
-    }
-    let(:expected_json_with_test) {
+    end
+    let(:expected_json_with_test) do
       {
         ApplicationDID: criteria.application_did,
         JobDID: criteria.job_did,
@@ -117,7 +126,6 @@ module Cb::Criteria::Application
         }],
         Test: true
       }.to_json
-    }
-
+    end
   end
 end

--- a/spec/cb/criteria/resumes/get_by_hash_spec.rb
+++ b/spec/cb/criteria/resumes/get_by_hash_spec.rb
@@ -1,18 +1,28 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   module Criteria
     module Resumes
       describe GetByHash do
-        let(:criteria) {
-          GetByHash.new({ resumeHash: 'hash', externalUserID: 'user'})
-        }
-        let(:expected_hash){
-          { :resume_hash => 'hash', :external_user_id => 'user' }
-        }
+        let(:criteria) do
+          GetByHash.new(resumeHash: 'hash', externalUserID: 'user')
+        end
+        let(:expected_hash) do
+          { resume_hash: 'hash', external_user_id: 'user' }
+        end
 
         describe '#to_hash' do
-          it { expect(criteria.to_hash).to eq(expected_hash)}
+          it { expect(criteria.to_hash).to eq(expected_hash) }
         end
       end
     end

--- a/spec/cb/criteria/user/change_password_spec.rb
+++ b/spec/cb/criteria/user/change_password_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Criteria::User::ChangePassword do
-
     before :all do
       @external_id                 = 'EXT135'
       @old_password                = 'MyOldPassword123'
@@ -10,10 +19,10 @@ module Cb
       @test                        = 'true'
 
       @user_change_password = Cb::Criteria::User::ChangePassword.new(
-          :external_id => @external_id,
-          :old_password => @old_password,
-          :new_password => @new_password,
-          :test => @test
+        external_id: @external_id,
+        old_password: @old_password,
+        new_password: @new_password,
+        test: @test
       )
     end
     context '.new' do
@@ -32,7 +41,6 @@ module Cb
 
         expect(returned_xml).to be_an_instance_of String
       end
-
     end
   end
 end

--- a/spec/cb/criteria/user/delete_spec.rb
+++ b/spec/cb/criteria/user/delete_spec.rb
@@ -1,18 +1,26 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Criteria::User::Delete do
-
     before :all do
-      @external_id                 = "ext_id"
-      @password                    = "pw"
-      @test                        = "true"
-
+      @external_id                 = 'ext_id'
+      @password                    = 'pw'
+      @test                        = 'true'
 
       @user_delete = Cb::Criteria::User::Delete.new(
-          :external_id => @external_id,
-          :password => @password,
-          :test => @test
+        external_id: @external_id,
+        password: @password,
+        test: @test
       )
     end
 

--- a/spec/cb/models/api_response_model_spec.rb
+++ b/spec/cb/models/api_response_model_spec.rb
@@ -60,9 +60,7 @@ module Cb
         end
 
         it '#set_model_properties' do
-          class FailDummyModel; def required_fields
-                                  []
-                                end end
+          class FailDummyModel; def required_fields; Array.new end end
           assert_not_implemented_method_name('set_model_properties') { FailDummyModel.new }
         end
       end

--- a/spec/cb/models/api_response_model_spec.rb
+++ b/spec/cb/models/api_response_model_spec.rb
@@ -1,11 +1,19 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   # this class is meant to be inherited, behavior is demonstrated using dummy classes!
   describe Cb::Models::ApiResponseModel do
-
     describe '#new' do
-
       context 'when the inheriting class overrides all required methods' do
         class ValidDummyModel < Cb::Models::ApiResponseModel
           def required_fields
@@ -13,7 +21,7 @@ module Cb
           end
 
           def set_model_properties
-            @stuff = api_response['potatoes'] || String.new
+            @stuff = api_response['potatoes'] || ''
           end
         end
 
@@ -29,7 +37,7 @@ module Cb
             @api_response = { 'no' => 'dice' }
             begin
               ValidDummyModel.new(@api_response)
-              raise 'test should not have made it this far!'
+              fail 'test should not have made it this far!'
             rescue ExpectedResponseFieldMissing => ex
               expect(ex.message.include?('potatoes hotdogs baconbaconbacon')).to eq true
             end
@@ -41,12 +49,10 @@ module Cb
         class FailDummyModel < Cb::Models::ApiResponseModel; end
 
         def assert_not_implemented_method_name(method_name, &expected_to_raise_error)
-          begin
-            expected_to_raise_error.call
-            raise 'this test should not have made it this far!' # fail if proc code does not raise error
-          rescue NotImplementedError => ex
-            expect(ex.message.include?(method_name)).to eq true
-          end
+          expected_to_raise_error.call
+          fail 'this test should not have made it this far!' # fail if proc code does not raise error
+        rescue NotImplementedError => ex
+          expect(ex.message.include?(method_name)).to eq true
         end
 
         it '#required_fields' do
@@ -54,11 +60,12 @@ module Cb
         end
 
         it '#set_model_properties' do
-          class FailDummyModel; def required_fields; Array.new end end
+          class FailDummyModel; def required_fields
+                                  []
+                                end end
           assert_not_implemented_method_name('set_model_properties') { FailDummyModel.new }
         end
       end
     end # new
-
   end
 end

--- a/spec/cb/models/implementations/application_external_spec.rb
+++ b/spec/cb/models/implementations/application_external_spec.rb
@@ -1,9 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Models
-
   describe ApplicationExternal do
-
     before :all do
       @job_did = 'J1234567890'
       @email = 'dontspammebro@whoa.net'
@@ -11,12 +19,11 @@ module Cb::Models
       @ipath = 'shivitandshivitgood'
       @is_external_link_apply = true
       @application = ApplicationExternal.new(
-        { job_did: @job_did,
-          email: @email,
-          site_id: @site_id,
-          is_external_link_apply: @is_external_link_apply,
-          ipath: @ipath
-        })
+        job_did: @job_did,
+        email: @email,
+        site_id: @site_id,
+        is_external_link_apply: @is_external_link_apply,
+        ipath: @ipath)
     end
 
     context '#new' do
@@ -46,7 +53,5 @@ module Cb::Models
         expect(returned_xml).to be_an_instance_of String
       end
     end
-
   end
-
 end

--- a/spec/cb/models/implementations/application_form_spec.rb
+++ b/spec/cb/models/implementations/application_form_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 describe Cb::Models::Application::Form do

--- a/spec/cb/models/implementations/application_spec.rb
+++ b/spec/cb/models/implementations/application_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Models
@@ -21,9 +31,9 @@ module Cb::Models
     end
 
     describe '#is_submitted' do
-      let(:application_hash) {
+      let(:application_hash) do
         replace_value_in_response_hash('IsSubmitted', is_submitted)
-      }
+      end
 
       context 'When IsSubmitted is nil' do
         let(:is_submitted) { nil }
@@ -33,14 +43,14 @@ module Cb::Models
       end
 
       context 'When IsSubmitted is "true"' do
-        let(:is_submitted) { "true" }
+        let(:is_submitted) { 'true' }
         it 'sets is_submitted as true' do
           expect(application.is_submitted).to be_truthy
         end
       end
 
       context 'When IsSubmitted is "false"' do
-        let(:is_submitted) { "false" }
+        let(:is_submitted) { 'false' }
         it 'sets is_submitted as true' do
           expect(application.is_submitted).to be_falsey
         end
@@ -73,9 +83,9 @@ module Cb::Models
         expect(application.tn_did).to be_nil
       end
       context 'When response hash has TNDID' do
-        let(:application_hash) {
+        let(:application_hash) do
           replace_value_in_response_hash('TNDID', 'TN******************')
-        }
+        end
 
         it 'sets tn_did to that value' do
           expect(application.tn_did).to eq 'TN******************'
@@ -88,9 +98,9 @@ module Cb::Models
         expect(application.redirect_url).to be_nil
       end
       context 'When response hash has redirectURL' do
-        let(:application_hash) {
+        let(:application_hash) do
           replace_value_in_response_hash('redirectURL', 'google.gov')
-        }
+        end
 
         it 'sets redirect_url to that value' do
           expect(application.redirect_url).to eq 'google.gov'
@@ -103,6 +113,5 @@ module Cb::Models
       hash[key] = value
       hash
     end
-
   end
 end

--- a/spec/cb/models/implementations/category_spec.rb
+++ b/spec/cb/models/implementations/category_spec.rb
@@ -1,8 +1,18 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Models
   describe Category do
-    context ".new" do
+    context '.new' do
       it 'should create a new cb category object' do
         args = { 'Name' => { '#text' => 'name', '@language' => 'lang' },
                  'Code' => 'code' }
@@ -10,11 +20,9 @@ module Cb::Models
 
         expect(category_obj.is_a?(Category)).to eq(true)
 
-
         expect(category_obj.CategoryCode).to eq('code')
         expect(category_obj.CategoryLanguage).to eq('lang')
         expect(category_obj.CategoryName).to eq('name')
-
       end
     end
   end

--- a/spec/cb/models/implementations/collapsed_job_results_spec.rb
+++ b/spec/cb/models/implementations/collapsed_job_results_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Models
@@ -9,12 +19,12 @@ module Cb::Models
         end
         let(:results_hash) do
           {
-              'SearchMetaData' => {
-                  'SearchLocations' => {
-                      'SearchLocation' => search_location
-                  }
-              },
-              'GroupedJobSearchResults' => {}
+            'SearchMetaData' => {
+              'SearchLocations' => {
+                'SearchLocation' => search_location
+              }
+            },
+            'GroupedJobSearchResults' => {}
           }
         end
 
@@ -26,8 +36,8 @@ module Cb::Models
         context 'When there is more than one SearchLocation' do
           let(:search_location) do
             [
-                { 'City' => 'Athens', 'StateCode' => 'B', 'CountryCode' => 'GR', 'PostalCode' => nil },
-                { 'City' => 'Norcross', 'StateCode' => 'GA', 'CountryCode' => 'US', 'PostalCode' => nil }
+              { 'City' => 'Athens', 'StateCode' => 'B', 'CountryCode' => 'GR', 'PostalCode' => nil },
+              { 'City' => 'Norcross', 'StateCode' => 'GA', 'CountryCode' => 'US', 'PostalCode' => nil }
             ]
           end
 

--- a/spec/cb/models/implementations/data_lists/resume_data_list_spec.rb
+++ b/spec/cb/models/implementations/data_lists/resume_data_list_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb

--- a/spec/cb/models/implementations/email_subscription_spec.rb
+++ b/spec/cb/models/implementations/email_subscription_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Models
@@ -9,20 +19,15 @@ module Cb::Models
         applicant_survey_invites = 'false'
         job_recs = 'true'
 
-
         subscription = EmailSubscription.new('CareerResources' => career_resources,
-                              'ProductSponsorInfo' => product_sponsor_info,
-                              'ApplicantSurveyInvites' => applicant_survey_invites,
-                              'JobRecs' => job_recs)
-
-
-
+                                             'ProductSponsorInfo' => product_sponsor_info,
+                                             'ApplicantSurveyInvites' => applicant_survey_invites,
+                                             'JobRecs' => job_recs)
 
         expect(subscription.career_resources).to eq(career_resources)
         expect(subscription.product_sponsor_info).to eq(product_sponsor_info)
         expect(subscription.applicant_survey_invites).to eq(applicant_survey_invites)
         expect(subscription.job_recs).to eq(job_recs)
-
       end
     end
   end

--- a/spec/cb/models/implementations/employee_type_spec.rb
+++ b/spec/cb/models/implementations/employee_type_spec.rb
@@ -1,6 +1,15 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 module Cb
   describe Models::EmployeeType do
-
     context '#new' do
       context 'when there is no input supplied' do
         def new_model
@@ -8,9 +17,9 @@ module Cb
         end
 
         it 'initializes with no args to empty string defaults' do
-          expect(new_model.code).    to eq String.new
-          expect(new_model.name).    to eq String.new
-          expect(new_model.language).to eq String.new
+          expect(new_model.code).    to eq ''
+          expect(new_model.name).    to eq ''
+          expect(new_model.language).to eq ''
         end
       end
 
@@ -30,6 +39,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/models/implementations/industry_spec.rb
+++ b/spec/cb/models/implementations/industry_spec.rb
@@ -1,12 +1,20 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Models
-
   describe Industry do
-
     context 'initialization' do
       it 'should create a new cb industry object' do
-        args = {'Code'=>'IND067', 'Name'=>{'@language'=>'en', '#text'=>'Accounting - Finance'}}
+        args = { 'Code' => 'IND067', 'Name' => { '@language' => 'en', '#text' => 'Accounting - Finance' } }
 
         industry_obj = Industry.new(args)
         expect(industry_obj).to be_kind_of(Industry)

--- a/spec/cb/models/implementations/job_branding_spec.rb
+++ b/spec/cb/models/implementations/job_branding_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Models
@@ -11,100 +21,97 @@ module Cb::Models
         errors = { 'Message' => 'There is no job branding for this Id.' }
         company_description = 'Company name ...'
 
-        media = 
-	        { 
-	        	'Header' => 'header?',
-	        	'HeaderType' => 'awesome',
-	        	'TabletBanner' => 'wut?',
-	        	'MobileLogo' => 'mobile, duh.',
-	        	'Footer' => 'the bottom',
-	        	'IsMultiVideo' => 'true'
-	        }
+        media =
+          {
+            'Header' => 'header?',
+            'HeaderType' => 'awesome',
+            'TabletBanner' => 'wut?',
+            'MobileLogo' => 'mobile, duh.',
+            'Footer' => 'the bottom',
+            'IsMultiVideo' => 'true'
+          }
 
-	    sections = 
-	    	{
-	    		'Page' => 
-	    			{
-	    				'Section1' => 'the one',
-	    				'Section2' => 'the two',
-	    				'Section3' => 'the three'
-	    			},
-	    		'JobDetails' => 
-	    			{
-	    				'Description' => 'the desc.',
-	    				'Requirements' => 'reqsss',
-	    				'Snapshot' => 'click click.'
-	    			}
-	    	}
+        sections =
+          {
+            'Page' =>
+              {
+                'Section1' => 'the one',
+                'Section2' => 'the two',
+                'Section3' => 'the three'
+              },
+            'JobDetails' =>
+              {
+                'Description' => 'the desc.',
+                'Requirements' => 'reqsss',
+                'Snapshot' => 'click click.'
+              }
+          }
 
-        styles = 
-        	{
-        		'Page' => 
-        			{
-        				'FontColor' => '#FFF',
-        				'FontSize' => '14px',
-        				'FontStyle' => 'Helvetica'
-        			},
-        		'JobDetails' =>
-        			{
-        				'Container' =>
-        					{
-        						'BorderColor' => '#FFA'
-        					},
-        				'Content' =>
-        					{
-        						'BorderRadius' => '4px'
-        					},
-        				'Headings' =>
-        					{
-        						'BoxShadow' => 'none'
-        					}
-        			},
-        		'CompanyInfo' =>
-        			{
-        				'Buttons' =>
-        					{
-        						'BackgroundColor' => '#CCC'
-        					},
-        				'Container' =>
-        					{
-        						'BackgroundImage' => 'http://image.is.here/23242.jpg'
-        					},
-        				'Content' =>
-        					{
-        						'BackgroundGradient' => 
-        							{
-        								'Color1' => '#F2323A',
-        								'Color2' => '#D245A2',
-        								'Orientation' => 'Horizontal'
-        							}
-        					},
-        				'Headings' =>
-        					{
-        						'BorderSize' => '3px'
-        					}
-        			}
-        	}
+        styles =
+          {
+            'Page' =>
+              {
+                'FontColor' => '#FFF',
+                'FontSize' => '14px',
+                'FontStyle' => 'Helvetica'
+              },
+            'JobDetails' =>
+              {
+                'Container' =>
+                  {
+                    'BorderColor' => '#FFA'
+                  },
+                'Content' =>
+                  {
+                    'BorderRadius' => '4px'
+                  },
+                'Headings' =>
+                  {
+                    'BoxShadow' => 'none'
+                  }
+              },
+            'CompanyInfo' =>
+              {
+                'Buttons' =>
+                  {
+                    'BackgroundColor' => '#CCC'
+                  },
+                'Container' =>
+                  {
+                    'BackgroundImage' => 'http://image.is.here/23242.jpg'
+                  },
+                'Content' =>
+                  {
+                    'BackgroundGradient' =>
+                      {
+                        'Color1' => '#F2323A',
+                        'Color2' => '#D245A2',
+                        'Orientation' => 'Horizontal'
+                      }
+                  },
+                'Headings' =>
+                  {
+                    'BorderSize' => '3px'
+                  }
+              }
+          }
 
-        widgets = { 
-        	'ShowWidgets' => 'true',
-        	'Youtube' => 'http://www.youtube.com'
+        widgets = {
+          'ShowWidgets' => 'true',
+          'Youtube' => 'http://www.youtube.com'
         }
 
-
         job_branding = Cb::Models::JobBranding.new(
-        	{
-	        	'Name' => name,
-	        	'Id' => id,
-	        	'AccountId' => account_id,
-	            'Type' => type,
-	            'Media' => media,
-	            'Styles' => styles,
-	            'Errors' => errors,
-	            'Sections' => sections,
-	            'Widgets' => widgets,
-                'CompanyDescription' => company_description
-	        })
+          'Name' => name,
+          'Id' => id,
+          'AccountId' => account_id,
+          'Type' => type,
+          'Media' => media,
+          'Styles' => styles,
+          'Errors' => errors,
+          'Sections' => sections,
+          'Widgets' => widgets,
+          'CompanyDescription' => company_description)
 
         expect(job_branding.name).to eq(name)
         expect(job_branding.id).to eq(id)

--- a/spec/cb/models/implementations/job_results_spec.rb
+++ b/spec/cb/models/implementations/job_results_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Models
@@ -25,8 +35,8 @@ module Cb::Models
         context 'When there is more than one SearchLocation' do
           let(:search_location) do
             [
-                { 'City' => 'Athens', 'StateCode' => 'B', 'CountryCode' => 'GR', 'PostalCode' => nil },
-                { 'City' => 'Norcross', 'StateCode' => 'GA', 'CountryCode' => 'US', 'PostalCode' => nil }
+              { 'City' => 'Athens', 'StateCode' => 'B', 'CountryCode' => 'GR', 'PostalCode' => nil },
+              { 'City' => 'Norcross', 'StateCode' => 'GA', 'CountryCode' => 'US', 'PostalCode' => nil }
             ]
           end
 

--- a/spec/cb/models/implementations/job_results_v3_spec.rb
+++ b/spec/cb/models/implementations/job_results_v3_spec.rb
@@ -1,14 +1,23 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Models
   describe JobResultsV3 do
     let(:search_response_hash) { YAML.load open('spec/support/response_stubs/search_result_v3.yml') }
     let(:search_results) { JobResultsV3.new(search_response_hash) }
-    
+
     describe '#api_result' do
-      
       it 'returns a Hash' do
-        expect(search_results.api_response).to be_instance_of(Hash) 
+        expect(search_results.api_response).to be_instance_of(Hash)
       end
     end
   end

--- a/spec/cb/models/implementations/job_spec.rb
+++ b/spec/cb/models/implementations/job_spec.rb
@@ -1,19 +1,27 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Models
   describe Job do
     describe '#initialize' do
-
       context 'When ApplyRequirements hash is contained in the hash passed into the constructor' do
         let(:job_hash) do
-          { 'ApplyRequirements' => { 'ApplyRequirement' => 'noonlineapply' }}
+          { 'ApplyRequirements' => { 'ApplyRequirement' => 'noonlineapply' } }
         end
 
         it 'then the apply_requirements field should be set' do
           job = Job.new job_hash
           expect(job.apply_requirements).to eq(['noonlineapply'])
         end
-
       end
     end
 
@@ -21,20 +29,20 @@ module Cb::Models
     # to the set of mappings below and it will test itself for you!
     context 'predicate methods:' do
       response_to_model_mappings = [
-        { :api_field => 'HasQuestionnaire',    :predicate_method => :has_questionnaire? },
-        { :api_field => 'CanBeQuickApplied',   :predicate_method => :can_be_quick_applied? },
-        { :api_field => 'ManagesOthers',       :predicate_method => :manages_others? },
-        { :api_field => 'IsScreenerApply',     :predicate_method => :screener_apply? },
-        { :api_field => 'IsSharedJob',         :predicate_method => :shared_job? },
-        { :api_field => 'RelocationCovered',   :predicate_method => :relocation_covered? },
-        { :api_field => 'ExternalApplication', :predicate_method => :external_application? },
+        { api_field: 'HasQuestionnaire',    predicate_method: :has_questionnaire? },
+        { api_field: 'CanBeQuickApplied',   predicate_method: :can_be_quick_applied? },
+        { api_field: 'ManagesOthers',       predicate_method: :manages_others? },
+        { api_field: 'IsScreenerApply',     predicate_method: :screener_apply? },
+        { api_field: 'IsSharedJob',         predicate_method: :shared_job? },
+        { api_field: 'RelocationCovered',   predicate_method: :relocation_covered? },
+        { api_field: 'ExternalApplication', predicate_method: :external_application? }
       ]
 
       response_to_model_mappings.each do |mapping|
         response_field_name = mapping[:api_field]
         predicate_method = mapping[:predicate_method]
 
-        context "#{response_field_name}/#{predicate_method}" do          
+        context "#{response_field_name}/#{predicate_method}" do
           context 'when in response and set to (string) ' do
             context 'True' do
               it 'should respond true' do
@@ -55,14 +63,13 @@ module Cb::Models
 
           context 'when not in response' do
             it 'returns false' do
-              job_hash = Hash.new
+              job_hash = {}
               job = Job.new(job_hash)
               expect(job.send(predicate_method)).to be_falsey
             end
           end
         end
       end
-
     end
   end
 end

--- a/spec/cb/models/implementations/recommended_job_spec.rb
+++ b/spec/cb/models/implementations/recommended_job_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Models
@@ -5,7 +15,7 @@ module Cb::Models
     describe '#new' do
       context 'When ApplyRequirements hash is containd in the hash passed into the constructor' do
         let(:job_hash) do
-          { 'ApplyRequirements' => { 'ApplyRequirement' => 'noonlineapply' }}
+          { 'ApplyRequirements' => { 'ApplyRequirement' => 'noonlineapply' } }
         end
 
         it 'then the apply_requirements field should be set' do
@@ -14,7 +24,5 @@ module Cb::Models
         end
       end
     end
-
-
   end
 end

--- a/spec/cb/models/implementations/resume/country_code_spec.rb
+++ b/spec/cb/models/implementations/resume/country_code_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -38,4 +48,3 @@ module Cb
     end
   end
 end
-

--- a/spec/cb/models/implementations/resume/language_code_spec.rb
+++ b/spec/cb/models/implementations/resume/language_code_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -17,7 +27,7 @@ module Cb
       end
 
       context 'given Name and Code' do
-        let(:args) { { key_name => name , key_code => code} }
+        let(:args) { { key_name => name, key_code => code } }
         let(:language_code) { Models::LanguageCode.new(args) }
 
         it { expect(language_code.name).to eq(name) }
@@ -31,13 +41,13 @@ module Cb
       end
 
       context 'missing Code' do
-        let(:language_code) { Models::LanguageCode.new({ key_name => name }) }
+        let(:language_code) { Models::LanguageCode.new(key_name => name) }
 
         it { expect(error).to eq(key_code) }
       end
 
       context 'missing Name' do
-        let(:language_code) { Models::LanguageCode.new({ key_code => code }) }
+        let(:language_code) { Models::LanguageCode.new(key_code => code) }
 
         it { expect(error).to eq(key_name) }
       end

--- a/spec/cb/models/implementations/resume/resume_spec.rb
+++ b/spec/cb/models/implementations/resume/resume_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb

--- a/spec/cb/models/implementations/saved_search_spec.rb
+++ b/spec/cb/models/implementations/saved_search_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -6,7 +16,7 @@ module Cb
       let(:saved_search) { Models::SavedSearch.new }
       let(:search_parameters) { Models::SavedSearch::SearchParameters.new }
 
-      context '.new' do 
+      context '.new' do
         it 'should create a new saved job search object' do
           external_user_id = 'XRHS3LN6G55WX61GXJG8'
           host_site = 'WR'
@@ -14,12 +24,12 @@ module Cb
           did = 'the id of the thing'
           is_daily_email = false
 
-          user_saved_search = Cb::Models::SavedSearch.new('IsDailyEmail'=>is_daily_email,
-                                                        'ExternalUserID'=>external_user_id, 'SearchName'=>search_name,
-                                                        'DID'=>did,
-                                                        'HostSite'=>host_site,
-                                                        'SearchParameters'=>mock_search_parameters_response)
-          
+          user_saved_search = Cb::Models::SavedSearch.new('IsDailyEmail' => is_daily_email,
+                                                          'ExternalUserID' => external_user_id, 'SearchName' => search_name,
+                                                          'DID' => did,
+                                                          'HostSite' => host_site,
+                                                          'SearchParameters' => mock_search_parameters_response)
+
           expect(user_saved_search).to be_a_kind_of(Cb::Models::SavedSearch)
           expect(user_saved_search.is_daily_email).to eq(is_daily_email)
           expect(user_saved_search.host_site).to eq(host_site)
@@ -32,44 +42,43 @@ module Cb
         it 'should create a search parameter ' do
           saved_search_parameters = Cb::Models::SavedSearch::SearchParameters.new(mock_search_parameters_response)
 
-          expect(saved_search_parameters.boolean_operator).to       eq("BooleanOperator")
-          expect(saved_search_parameters.category).to               eq("Category")
-          expect(saved_search_parameters.city).to                   eq("City")
-          expect(saved_search_parameters.company).to                eq("Company")
-          expect(saved_search_parameters.country).to                eq("Country")
-          expect(saved_search_parameters.education_code).to         eq("EducationCode")
-          expect(saved_search_parameters.emp_type).to               eq("EmpType")
-          expect(saved_search_parameters.exclude_company_names).to  eq("ExcludeCompanyNames")
-          expect(saved_search_parameters.exclude_job_titles).to     eq("ExcludeJobTitles")
-          expect(saved_search_parameters.exclude_keywords).to       eq("ExcludeKeywords")
-          expect(saved_search_parameters.exclude_national).to       eq("ExcludeNational")
-          expect(saved_search_parameters.industry_codes).to         eq("IndustryCodes")
-          expect(saved_search_parameters.jc_advertiser_flags).to    eq("JCAdvertiserFlags")
-          expect(saved_search_parameters.jc_job_nature).to          eq("JCJobNature")
-          expect(saved_search_parameters.jc_location).to            eq("JCLocation")
-          expect(saved_search_parameters.jc_position_level).to      eq("JCPositionLevel")
-          expect(saved_search_parameters.job_category).to           eq("")
-          expect(saved_search_parameters.job_title).to              eq("JobTitle")
-          expect(saved_search_parameters.keywords).to               eq("Keywords")
-          expect(saved_search_parameters.location).to               eq("Location")
-          expect(saved_search_parameters.order_by).to               eq("OrderBy")
-          expect(saved_search_parameters.order_direction).to        eq("OrderDirection")
-          expect(saved_search_parameters.pay_high).to               eq("PayHigh")
-          expect(saved_search_parameters.pay_info_only).to          eq("PayInfoOnly")
-          expect(saved_search_parameters.pay_low).to                eq("PayLow")
-          expect(saved_search_parameters.posted_within).to          eq("PostedWithin")
-          expect(saved_search_parameters.radius).to                 eq("Radius")
-          expect(saved_search_parameters.specific_education).to     eq("SpecificEducation")
-          expect(saved_search_parameters.state).to                  eq("State")
+          expect(saved_search_parameters.boolean_operator).to eq('BooleanOperator')
+          expect(saved_search_parameters.category).to eq('Category')
+          expect(saved_search_parameters.city).to eq('City')
+          expect(saved_search_parameters.company).to eq('Company')
+          expect(saved_search_parameters.country).to eq('Country')
+          expect(saved_search_parameters.education_code).to eq('EducationCode')
+          expect(saved_search_parameters.emp_type).to eq('EmpType')
+          expect(saved_search_parameters.exclude_company_names).to eq('ExcludeCompanyNames')
+          expect(saved_search_parameters.exclude_job_titles).to eq('ExcludeJobTitles')
+          expect(saved_search_parameters.exclude_keywords).to eq('ExcludeKeywords')
+          expect(saved_search_parameters.exclude_national).to eq('ExcludeNational')
+          expect(saved_search_parameters.industry_codes).to eq('IndustryCodes')
+          expect(saved_search_parameters.jc_advertiser_flags).to eq('JCAdvertiserFlags')
+          expect(saved_search_parameters.jc_job_nature).to eq('JCJobNature')
+          expect(saved_search_parameters.jc_location).to eq('JCLocation')
+          expect(saved_search_parameters.jc_position_level).to eq('JCPositionLevel')
+          expect(saved_search_parameters.job_category).to eq('')
+          expect(saved_search_parameters.job_title).to eq('JobTitle')
+          expect(saved_search_parameters.keywords).to eq('Keywords')
+          expect(saved_search_parameters.location).to eq('Location')
+          expect(saved_search_parameters.order_by).to eq('OrderBy')
+          expect(saved_search_parameters.order_direction).to eq('OrderDirection')
+          expect(saved_search_parameters.pay_high).to eq('PayHigh')
+          expect(saved_search_parameters.pay_info_only).to eq('PayInfoOnly')
+          expect(saved_search_parameters.pay_low).to eq('PayLow')
+          expect(saved_search_parameters.posted_within).to eq('PostedWithin')
+          expect(saved_search_parameters.radius).to eq('Radius')
+          expect(saved_search_parameters.specific_education).to eq('SpecificEducation')
+          expect(saved_search_parameters.state).to eq('State')
         end
-
       end
 
       describe '#delete_anon_to_xml' do
-        before {
+        before do
           saved_search.external_id = 'BigMoom'
           Cb.configuration.dev_key = 'who dat'
-        }
+        end
         it 'serialized correctly' do
           xml = saved_search.delete_anon_to_xml
           expect(xml).to eq <<-eos
@@ -83,7 +92,7 @@ module Cb
       end
 
       describe '#create_to_xml' do
-        before {
+        before do
           saved_search.host_site = 'US'
           saved_search.cobrand = 'AOLer'
           saved_search.search_name = 'Yolo'
@@ -92,9 +101,8 @@ module Cb
           saved_search.is_daily_email = true
           saved_search.external_user_id = 'BigMoomGuy'
           Cb.configuration.dev_key = 'who dat'
-        }
+        end
         it 'serialized correctly' do
-
           xml = saved_search.create_to_xml
           expect(xml).to eq <<-eos
           <Request>
@@ -111,7 +119,7 @@ module Cb
       end
 
       describe '#create_anon_to_xml' do
-        before {
+        before do
           saved_search.host_site = 'US'
           saved_search.cobrand = 'AOLer'
           saved_search.browser_id = 'my_bid'
@@ -122,9 +130,8 @@ module Cb
           saved_search.search_parameters = search_parameters
           saved_search.is_daily_email = true
           Cb.configuration.dev_key = 'who dat'
-        }
+        end
         it 'serialized correctly' do
-
           xml = saved_search.create_anon_to_xml
           expect(xml).to eq <<-eos
           <Request>
@@ -144,45 +151,44 @@ module Cb
       end
 
       describe '#update_to_json' do
-        before {
+        before do
           saved_search.host_site = 'US'
           saved_search.cobrand = 'AOLer'
           saved_search.search_name = 'Yolo'
           add_search_params
           saved_search.search_parameters = search_parameters
           saved_search.is_daily_email = true
-          saved_search.email_delivery_day = "FRIDAY, GET DOWN ON IT"
+          saved_search.email_delivery_day = 'FRIDAY, GET DOWN ON IT'
           saved_search.did = 'Mooma did'
           saved_search.user_oauth_token = 'My token, mmhmmm yes'
           Cb.configuration.dev_key = 'who dat'
-        }
+        end
         it 'serialized correctly with daily email true' do
-
           json = saved_search.update_to_json
           expect(json).to eq ({
-              "DID" => "Mooma did",
-              "SearchName" => "Yolo",
-              "HostSite" => "US",
-              "SiteID" => "",
-              "Cobrand" => "AOLer",
-              "IsDailyEmail" => true,
-              "userOAuthToken" => "My token, mmhmmm yes",
-              "SavedSearchParameters" => search_parameters.to_hash
+            'DID' => 'Mooma did',
+            'SearchName' => 'Yolo',
+            'HostSite' => 'US',
+            'SiteID' => '',
+            'Cobrand' => 'AOLer',
+            'IsDailyEmail' => true,
+            'userOAuthToken' => 'My token, mmhmmm yes',
+            'SavedSearchParameters' => search_parameters.to_hash
           }.to_json)
         end
         it 'serialized correctly with daily email false' do
           saved_search.is_daily_email = false
           json = saved_search.update_to_json
           expect(json).to eq ({
-              "DID" => "Mooma did",
-              "SearchName" => "Yolo",
-              "HostSite" => "US",
-              "SiteID" => "",
-              "Cobrand" => "AOLer",
-              "IsDailyEmail" => false,
-              "userOAuthToken" => "My token, mmhmmm yes",
-              "SavedSearchParameters" => search_parameters.to_hash,
-              "EmailDeliveryDay" => "FRIDAY, GET DOWN ON IT"
+            'DID' => 'Mooma did',
+            'SearchName' => 'Yolo',
+            'HostSite' => 'US',
+            'SiteID' => '',
+            'Cobrand' => 'AOLer',
+            'IsDailyEmail' => false,
+            'userOAuthToken' => 'My token, mmhmmm yes',
+            'SavedSearchParameters' => search_parameters.to_hash,
+            'EmailDeliveryDay' => 'FRIDAY, GET DOWN ON IT'
           }.to_json)
         end
       end
@@ -276,7 +282,6 @@ module Cb
         "Country":"country"
         '
       end
-
     end
   end
 end

--- a/spec/cb/models/implementations/state_spec.rb
+++ b/spec/cb/models/implementations/state_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -8,8 +18,8 @@ module Cb
       context 'a state_hash is valid' do
         let(:state_hash) do
           {
-              'StateId' => 'AL',
-              'StateName' => 'Alabama'
+            'StateId' => 'AL',
+            'StateName' => 'Alabama'
           }
         end
         it { expect(state.key).to eq('AL') }

--- a/spec/cb/models/implementations/talent_network_spec.rb
+++ b/spec/cb/models/implementations/talent_network_spec.rb
@@ -1,28 +1,38 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb::Models
   describe TalentNetwork do
-    context '.new' do 
-      it 'should create a new talent network object' do 
+    context '.new' do
+      it 'should create a new talent network object' do
         tn_obj = TalentNetwork.new
         expect(tn_obj.class).to be == TalentNetwork
       end
 
-      it 'should return no join questions on create' do 
+      it 'should return no join questions on create' do
         tn_obj = TalentNetwork.new
         expect(tn_obj.join_form_questions.size).to eq(0)
       end
 
-      it 'should return at least one join question' do 
-        args = Hash.new
+      it 'should return at least one join question' do
+        args = {}
         args['JoinQuestions'] = [
           {
-            "Text" => "Blah",
-            "OptionDisplayType" => "Blah"
-          }, 
+            'Text' => 'Blah',
+            'OptionDisplayType' => 'Blah'
+          },
           {
-            "Text" => "Blah2",
-            "OptionDisplayType" => "Blah2"
+            'Text' => 'Blah2',
+            'OptionDisplayType' => 'Blah2'
           }
         ]
 
@@ -33,30 +43,29 @@ module Cb::Models
   end
 
   describe TalentNetwork::Member do
-    context '.new' do 
-      it 'should create a member object' do 
+    context '.new' do
+      it 'should create a member object' do
         m_obj = TalentNetwork::Member.new
         expect(m_obj.class).to be == TalentNetwork::Member
       end
 
-      it 'should be able to give back join values' do 
-        args = Hash.new
-        args['JoinValues'] = ['blah', 'bla1', 'hello', 'world']
+      it 'should be able to give back join values' do
+        args = {}
+        args['JoinValues'] = %w(blah bla1 hello world)
 
         m_obj = TalentNetwork::Member.new(args)
-        expect(m_obj.join_values.class).to be == Array 
+        expect(m_obj.join_values.class).to be == Array
       end
     end
-
   end
-  describe TalentNetwork::Questions do 
-    context '.new' do 
-      it 'should create a new question object' do 
+  describe TalentNetwork::Questions do
+    context '.new' do
+      it 'should create a new question object' do
         q_obj = TalentNetwork::Questions.new
         expect(q_obj.class).to be == TalentNetwork::Questions
       end
 
-      it 'should return empty tn questions when no args supplied' do 
+      it 'should return empty tn questions when no args supplied' do
         q_obj = TalentNetwork::Questions.new
         expect(q_obj.text).to eq('')
         expect(q_obj.form_value).to eq('')
@@ -66,14 +75,14 @@ module Cb::Models
         expect(q_obj.options.size).to eq(0)
       end
 
-      it 'should return tn questions supplied into args' do 
-        args = Hash.new
+      it 'should return tn questions supplied into args' do
+        args = {}
         args['Text'] = 'Hello'
         args['FormValue'] = 'MxDot_Whatever'
         args['OptionDisplayType'] = 'World'
 
         q_obj = TalentNetwork::Questions.new(args)
-        
+
         expect(q_obj.text).to eq(args['Text'])
         expect(q_obj.form_value).to eq(args['FormValue'])
         expect(q_obj.option_display_type).to eq(args['OptionDisplayType'])
@@ -83,12 +92,12 @@ module Cb::Models
       end
 
       it 'should return at least one tn option' do
-        args = Hash.new
-        args["Options"] = [
+        args = {}
+        args['Options'] = [
           {
-            "Value" => 1,
-            "Order" => "Ascending",
-            "DisplayText" => "Blah"
+            'Value' => 1,
+            'Order' => 'Ascending',
+            'DisplayText' => 'Blah'
           }
         ]
 
@@ -98,9 +107,9 @@ module Cb::Models
     end
   end
 
-  describe TalentNetwork::Options do 
-    context '.new' do 
-      it 'should create an options object' do 
+  describe TalentNetwork::Options do
+    context '.new' do
+      it 'should create an options object' do
         opt_obj = TalentNetwork::Options.new
         expect(opt_obj.class).to be == TalentNetwork::Options
       end
@@ -112,8 +121,8 @@ module Cb::Models
         expect(opt_obj.display_text).to eq('')
       end
 
-      it 'should return tn options when args supplied' do 
-        args = Hash.new
+      it 'should return tn options when args supplied' do
+        args = {}
         args['Value'] = 1
         args['Order'] = 'Ascending'
 
@@ -125,22 +134,22 @@ module Cb::Models
     end
   end
 
-  describe TalentNetwork::JobInfo do 
-    context '.new' do 
-      it 'should create a job info object' do 
+  describe TalentNetwork::JobInfo do
+    context '.new' do
+      it 'should create a job info object' do
         jinfo_obj = TalentNetwork::JobInfo.new
         expect(jinfo_obj.class).to be == TalentNetwork::JobInfo
       end
 
-      it 'should return empty job info when no args supplied' do 
+      it 'should return empty job info when no args supplied' do
         jinfo_obj = TalentNetwork::JobInfo.new
         expect(jinfo_obj.join_form_url).to eq('')
         expect(jinfo_obj.tn_did).to eq('')
         expect(jinfo_obj.join_form_intercept_enabled).to eq('')
       end
 
-      it 'should return job information when args supplied' do 
-        args = Hash.new
+      it 'should return job information when args supplied' do
+        args = {}
         args['sTNDID'] = 'SomeJobDID'
 
         jinfo_obj = TalentNetwork::JobInfo.new(args)
@@ -151,9 +160,9 @@ module Cb::Models
     end
   end
 
-  describe TalentNetwork::JoinFormGeo do 
-    context '.new' do 
-      it 'should create a join form geo object' do 
+  describe TalentNetwork::JoinFormGeo do
+    context '.new' do
+      it 'should create a join form geo object' do
         jfgeo_obj = TalentNetwork::JoinFormGeo.new
         expect(jfgeo_obj.class).to be == TalentNetwork::JoinFormGeo
       end
@@ -164,15 +173,15 @@ module Cb::Models
         expect(jfgeo_obj.states.size).to eq(0)
       end
 
-      it 'should return countries and states as a hash when args supplied' do 
-        args = Hash.new
+      it 'should return countries and states as a hash when args supplied' do
+        args = {}
         args['Countries'] = {
-          "Value" => ['aa', 'bb', 'cc'],
-          "Display" => ['aaaaa', 'bbbbb', 'ccccc']
+          'Value' => %w(aa bb cc),
+          'Display' => %w(aaaaa bbbbb ccccc)
         }
         args['States'] = {
-          "Value" => ['aa', 'bb', 'cc'],
-          "Display" => ['aaaaa', 'bbbbb', 'ccccc']
+          'Value' => %w(aa bb cc),
+          'Display' => %w(aaaaa bbbbb ccccc)
         }
 
         jfgeo_obj = TalentNetwork::JoinFormGeo.new(args)
@@ -182,36 +191,36 @@ module Cb::Models
     end
   end
 
-  describe TalentNetwork::JoinFormGeoLocation do 
-    context '.new' do 
-      it 'should create a new join form geo location object' do 
+  describe TalentNetwork::JoinFormGeoLocation do
+    context '.new' do
+      it 'should create a new join form geo location object' do
         jfgl_obj = TalentNetwork::JoinFormGeoLocation.new
         expect(jfgl_obj.class).to be == TalentNetwork::JoinFormGeoLocation
       end
 
-      it 'should return empty geo hash when no args supplied' do 
+      it 'should return empty geo hash when no args supplied' do
         jfgl_obj = TalentNetwork::JoinFormGeoLocation.new
         expect(jfgl_obj.geo_hash.length).to eq(0)
       end
 
-      it 'should return a filled hash when args are supplied' do 
-        args = Hash.new
-        args['Value'] = ['aa', 'bb', 'cc']
-        args['Display'] = ['aaa', 'bbb', 'ccc']
+      it 'should return a filled hash when args are supplied' do
+        args = {}
+        args['Value'] = %w(aa bb cc)
+        args['Display'] = %w(aaa bbb ccc)
         jfgl_obj = TalentNetwork::JoinFormGeoLocation.new(args)
         expect(jfgl_obj.geo_hash.length).to be > 0
       end
     end
   end
 
-  describe TalentNetwork::JoinFormBranding do 
-    context '.new' do 
-      it 'should create a new join form branding object' do 
+  describe TalentNetwork::JoinFormBranding do
+    context '.new' do
+      it 'should create a new join form branding object' do
         jfb_obj = TalentNetwork::JoinFormBranding.new
         expect(jfb_obj.class).to be == TalentNetwork::JoinFormBranding
       end
 
-      it 'should return no branding information when args are not supplied' do 
+      it 'should return no branding information when args are not supplied' do
         jfb_obj = TalentNetwork::JoinFormBranding.new
         expect(jfb_obj.stylesheet_url).to eq('')
         expect(jfb_obj.join_logo_image_url).to eq('')
@@ -222,8 +231,8 @@ module Cb::Models
         expect(jfb_obj.site_path).to eq('')
       end
 
-      it 'should return branding info when args supplied' do 
-        args = Hash.new
+      it 'should return branding info when args supplied' do
+        args = {}
         args['StylesheetURL'] = 'https://blah.com/my.css'
         args['JoinLogoImageURL'] = 'https://secure.com/my.png'
 

--- a/spec/cb/models/implementations/user_spec.rb
+++ b/spec/cb/models/implementations/user_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -19,9 +29,8 @@ module Cb
           phone = '706-123-4567'
           created = Time.now
           gender = 'male'
-          birth_date = Date.today-40
+          birth_date = Date.today - 40
           work_status = 'US Citizen'
-
 
           user = Cb::Models::User.new(
             'ResponseExternalID' => external_id,
@@ -74,26 +83,25 @@ module Cb
           phone = '706-123-4567'
           created = Time.now
           gender = 'male'
-          birth_date = Date.today-40
+          birth_date = Date.today - 40
           work_status = 'US Citizen'
 
-
           user = Cb::Models::User.new(
-              'ResponseExternalID' => external_id,
-              'UserStatus' => user_status,
-              'Email' => email,
-              'Address1' => address_1,
-              'City' => city,
-              'State' => state,
-              'PostalCode' => postal_code,
-              'CountryCode' => country_code,
-              'FirstName' => first_name,
-              'LastName' => last_name,
-              'Phone' => phone,
-              'CreatedDT' => created,
-              'Gender' => gender,
-              'BirthDate' => birth_date,
-              'WorkStatus' => work_status)
+            'ResponseExternalID' => external_id,
+            'UserStatus' => user_status,
+            'Email' => email,
+            'Address1' => address_1,
+            'City' => city,
+            'State' => state,
+            'PostalCode' => postal_code,
+            'CountryCode' => country_code,
+            'FirstName' => first_name,
+            'LastName' => last_name,
+            'Phone' => phone,
+            'CreatedDT' => created,
+            'Gender' => gender,
+            'BirthDate' => birth_date,
+            'WorkStatus' => work_status)
 
           expect(user.external_id).to eq(external_id)
           expect(user.user_status).to eq(user_status)
@@ -112,7 +120,7 @@ module Cb
           expect(user.work_status).to eq(work_status)
         end
       end
-      
+
       context 'when no args provided' do
         it 'should create an empty user model' do
           user = Cb::Models::User.new
@@ -152,14 +160,14 @@ module Cb
 
     context '.custom_value' do
       it 'should successfully find custom value' do
-        user = Cb::Models::User.new('CustomValues' => {'CustomValue' => {'Key' => 'CustomKey', 'Value' => 'CustomVal'}})
+        user = Cb::Models::User.new('CustomValues' => { 'CustomValue' => { 'Key' => 'CustomKey', 'Value' => 'CustomVal' } })
 
         expect(user.custom_value('CustomKey')).to be == 'CustomVal'
         expect(user.custom_value('CustomKeyDoesNotExist').nil?).to be true
       end
 
       it 'should successfully find custom value in user with multiple custom values' do
-        user = Cb::Models::User.new('CustomValues' => {'CustomValue' => [{'Key' => 'CustomKey', 'Value' => 'CustomVal'}, {'Key' => 'CustomKey2', 'Value' => 'CustomVal2'}]})
+        user = Cb::Models::User.new('CustomValues' => { 'CustomValue' => [{ 'Key' => 'CustomKey', 'Value' => 'CustomVal' }, { 'Key' => 'CustomKey2', 'Value' => 'CustomVal2' }] })
 
         expect(user.custom_value('CustomKey')).to be == 'CustomVal'
         expect(user.custom_value('CustomKey2')).to be == 'CustomVal2'

--- a/spec/cb/requests/anonymous_saved_search/create_spec.rb
+++ b/spec/cb/requests/anonymous_saved_search/create_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::AnonymousSavedSearch::Create do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::AnonymousSavedSearch::Create.new({}) }
@@ -40,39 +49,37 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::AnonymousSavedSearch::Create.new({
-            host_site: 'host site',
-            test: 'true',
-            cobrand: 'cobrand',
-            browser_id: 'browser id',
-            session_id: 'session id',
-            email_address: 'email@example.com',
-            search_name: 'search name',
-            search_parameters: {
-              boolean_operator: 'boolean operator',
-              job_category: 'job category',
-              education_code: 'education code',
-              emp_type: 'emp type',
-              exclude_company_names: 'exclude company names',
-              exclude_job_titles: 'exclude job titles',
-              exclude_keywords: 'exclude keywords',
-              country: 'country',
-              industry_codes: 'industry codes',
-              job_title: 'job title',
-              keywords: 'jobs',
-              location: 'atlanta',
-              order_by: 'order by',
-              order_direction: 'order direction',
-              pay_high: '100',
-              pay_low: '10',
-              posted_within: '3',
-              radius: '50',
-              specific_education: 'false',
-              exclude_national: 'false',
-              pay_info_only: 'false'
-            },
-            is_daily_email: true
-          })
+          @request = Cb::Requests::AnonymousSavedSearch::Create.new(host_site: 'host site',
+                                                                    test: 'true',
+                                                                    cobrand: 'cobrand',
+                                                                    browser_id: 'browser id',
+                                                                    session_id: 'session id',
+                                                                    email_address: 'email@example.com',
+                                                                    search_name: 'search name',
+                                                                    search_parameters: {
+                                                                      boolean_operator: 'boolean operator',
+                                                                      job_category: 'job category',
+                                                                      education_code: 'education code',
+                                                                      emp_type: 'emp type',
+                                                                      exclude_company_names: 'exclude company names',
+                                                                      exclude_job_titles: 'exclude job titles',
+                                                                      exclude_keywords: 'exclude keywords',
+                                                                      country: 'country',
+                                                                      industry_codes: 'industry codes',
+                                                                      job_title: 'job title',
+                                                                      keywords: 'jobs',
+                                                                      location: 'atlanta',
+                                                                      order_by: 'order by',
+                                                                      order_direction: 'order direction',
+                                                                      pay_high: '100',
+                                                                      pay_low: '10',
+                                                                      posted_within: '3',
+                                                                      radius: '50',
+                                                                      specific_education: 'false',
+                                                                      exclude_national: 'false',
+                                                                      pay_info_only: 'false'
+                                                                    },
+                                                                    is_daily_email: true)
         end
 
         it 'should be correctly configured' do
@@ -129,6 +136,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/anonymous_saved_search/delete_spec.rb
+++ b/spec/cb/requests/anonymous_saved_search/delete_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::AnonymousSavedSearch::Delete do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::AnonymousSavedSearch::Delete.new({}) }
@@ -33,10 +42,8 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::AnonymousSavedSearch::Delete.new({
-            external_id: 'external id',
-            test: 'true',
-          })
+          @request = Cb::Requests::AnonymousSavedSearch::Delete.new(external_id: 'external id',
+                                                                    test: 'true')
         end
 
         it 'should be correctly configured' do
@@ -63,6 +70,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/application/create_spec.rb
+++ b/spec/cb/requests/application/create_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::Application::Create do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::Application::Create.new({}) }
@@ -17,11 +26,9 @@ module Cb
         end
 
         it 'should have basic headers' do
-          expect(@request.headers).to eq({
-            'DeveloperKey' => Cb.configuration.dev_key,
-            'HostSite' => Cb.configuration.host_site,
-            'Content-Type' => 'application/json'
-          })
+          expect(@request.headers).to eq('DeveloperKey' => Cb.configuration.dev_key,
+                                         'HostSite' => Cb.configuration.host_site,
+                                         'Content-Type' => 'application/json')
         end
 
         it 'should have a basic body' do
@@ -47,43 +54,41 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::Application::Create.new({
-            job_did: 'job did',
-            is_submitted: 'is submitted',
-            external_user_id: 'external user id',
-            vid: 'vid',
-            bid: 'bid',
-            sid: 'sid',
-            site_id: 'site id',
-            ipath_id: 'ipath id',
-            tn_did: 'tn did',
-            host_site: 'GR',
-            resume: {
-              external_resume_id: 'external resume id',
-              resume_file_name: 'resume file name',
-              resume_data: 'resume data',
-              resume_extension: 'resume extension',
-              resume_title: 'resume title'
-            },
-            cover_letter: {
-              cover_letter_id: 'cover letter id',
-              cover_letter_text: 'cover letter text',
-              cover_letter_title: 'cover letter title'
-            },
-            responses: [
-              {
-                question_id: 1,
-                response_text: "hello 1"},
-              {
-                question_id: 2,
-                response_text: "hello 2"},
-              {
-                question_id: 3,
-                response_text: "hello 3"
-              }
-            ],
-            test: true
-          })
+          @request = Cb::Requests::Application::Create.new(job_did: 'job did',
+                                                           is_submitted: 'is submitted',
+                                                           external_user_id: 'external user id',
+                                                           vid: 'vid',
+                                                           bid: 'bid',
+                                                           sid: 'sid',
+                                                           site_id: 'site id',
+                                                           ipath_id: 'ipath id',
+                                                           tn_did: 'tn did',
+                                                           host_site: 'GR',
+                                                           resume: {
+                                                             external_resume_id: 'external resume id',
+                                                             resume_file_name: 'resume file name',
+                                                             resume_data: 'resume data',
+                                                             resume_extension: 'resume extension',
+                                                             resume_title: 'resume title'
+                                                           },
+                                                           cover_letter: {
+                                                             cover_letter_id: 'cover letter id',
+                                                             cover_letter_text: 'cover letter text',
+                                                             cover_letter_title: 'cover letter title'
+                                                           },
+                                                           responses: [
+                                                             {
+                                                               question_id: 1,
+                                                               response_text: 'hello 1' },
+                                                             {
+                                                               question_id: 2,
+                                                               response_text: 'hello 2' },
+                                                             {
+                                                               question_id: 3,
+                                                               response_text: 'hello 3'
+                                                             }
+                                                           ],
+                                                           test: true)
         end
 
         it 'should be correctly configured' do
@@ -96,11 +101,9 @@ module Cb
         end
 
         it 'should have basic headers' do
-          expect(@request.headers).to eq({
-            'DeveloperKey' => Cb.configuration.dev_key,
-            'HostSite' => 'GR',
-            'Content-Type' => 'application/json'
-          })
+          expect(@request.headers).to eq('DeveloperKey' => Cb.configuration.dev_key,
+                                         'HostSite' => 'GR',
+                                         'Content-Type' => 'application/json')
         end
 
         it 'should have a basic body' do
@@ -147,6 +150,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/application/form_spec.rb
+++ b/spec/cb/requests/application/form_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::Application::Form do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::Application::Form.new({}) }
@@ -17,11 +26,9 @@ module Cb
         end
 
         it 'should have basic headers' do
-          expect(@request.headers).to eq({
-            'DeveloperKey' => Cb.configuration.dev_key,
-            'HostSite' => Cb.configuration.host_site,
-            'Content-Type' => 'application/json'
-          })
+          expect(@request.headers).to eq('DeveloperKey' => Cb.configuration.dev_key,
+                                         'HostSite' => Cb.configuration.host_site,
+                                         'Content-Type' => 'application/json')
         end
 
         it 'should have a basic body' do
@@ -31,9 +38,7 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::Application::Form.new({
-            application_did: 'app did'
-          })
+          @request = Cb::Requests::Application::Form.new(application_did: 'app did')
         end
 
         it 'should be correctly configured' do
@@ -46,11 +51,9 @@ module Cb
         end
 
         it 'should have basic headers' do
-          expect(@request.headers).to eq({
-            'DeveloperKey' => Cb.configuration.dev_key,
-            'HostSite' => Cb.configuration.host_site,
-            'Content-Type' => 'application/json'
-          })
+          expect(@request.headers).to eq('DeveloperKey' => Cb.configuration.dev_key,
+                                         'HostSite' => Cb.configuration.host_site,
+                                         'Content-Type' => 'application/json')
         end
 
         it 'should have a basic body' do
@@ -58,6 +61,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/application/get_spec.rb
+++ b/spec/cb/requests/application/get_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::Application::Get do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::Application::Get.new({}) }
@@ -17,11 +26,9 @@ module Cb
         end
 
         it 'should have basic headers' do
-          expect(@request.headers).to eq({
-            'DeveloperKey' => Cb.configuration.dev_key,
-            'HostSite' => Cb.configuration.host_site,
-            'Content-Type' => 'application/json'
-          })
+          expect(@request.headers).to eq('DeveloperKey' => Cb.configuration.dev_key,
+                                         'HostSite' => Cb.configuration.host_site,
+                                         'Content-Type' => 'application/json')
         end
 
         it 'should have a basic body' do
@@ -31,9 +38,7 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::Application::Get.new({
-            did: 'app did'
-          })
+          @request = Cb::Requests::Application::Get.new(did: 'app did')
         end
 
         it 'should be correctly configured' do
@@ -46,11 +51,9 @@ module Cb
         end
 
         it 'should have basic headers' do
-          expect(@request.headers).to eq({
-            'DeveloperKey' => Cb.configuration.dev_key,
-            'HostSite' => Cb.configuration.host_site,
-            'Content-Type' => 'application/json'
-          })
+          expect(@request.headers).to eq('DeveloperKey' => Cb.configuration.dev_key,
+                                         'HostSite' => Cb.configuration.host_site,
+                                         'Content-Type' => 'application/json')
         end
 
         it 'should have a basic body' do
@@ -58,6 +61,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/application/update_spec.rb
+++ b/spec/cb/requests/application/update_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::Application::Update do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::Application::Update.new({}) }
@@ -17,11 +26,9 @@ module Cb
         end
 
         it 'should have basic headers' do
-          expect(@request.headers).to eq({
-            'DeveloperKey' => Cb.configuration.dev_key,
-            'HostSite' => Cb.configuration.host_site,
-            'Content-Type' => 'application/json'
-          })
+          expect(@request.headers).to eq('DeveloperKey' => Cb.configuration.dev_key,
+                                         'HostSite' => Cb.configuration.host_site,
+                                         'Content-Type' => 'application/json')
         end
 
         it 'should have a basic body' do
@@ -48,43 +55,41 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::Application::Update.new({
-            application_did: 'app did',
-            job_did: 'job did',
-            is_submitted: 'is submitted',
-            external_user_id: 'external user id',
-            vid: 'vid',
-            bid: 'bid',
-            sid: 'sid',
-            site_id: 'site id',
-            ipath_id: 'ipath id',
-            tn_did: 'tn did',
-            resume: {
-              external_resume_id: 'external resume id',
-              resume_file_name: 'resume file name',
-              resume_data: 'resume data',
-              resume_extension: 'resume extension',
-              resume_title: 'resume title'
-            },
-            cover_letter: {
-              cover_letter_id: 'cover letter id',
-              cover_letter_text: 'cover letter text',
-              cover_letter_title: 'cover letter title'
-            },
-            responses: [
-              {
-                question_id: 1,
-                response_text: "hello 1"},
-              {
-                question_id: 2,
-                response_text: "hello 2"},
-              {
-                question_id: 3,
-                response_text: "hello 3"
-              }
-            ],
-            test: true
-          })
+          @request = Cb::Requests::Application::Update.new(application_did: 'app did',
+                                                           job_did: 'job did',
+                                                           is_submitted: 'is submitted',
+                                                           external_user_id: 'external user id',
+                                                           vid: 'vid',
+                                                           bid: 'bid',
+                                                           sid: 'sid',
+                                                           site_id: 'site id',
+                                                           ipath_id: 'ipath id',
+                                                           tn_did: 'tn did',
+                                                           resume: {
+                                                             external_resume_id: 'external resume id',
+                                                             resume_file_name: 'resume file name',
+                                                             resume_data: 'resume data',
+                                                             resume_extension: 'resume extension',
+                                                             resume_title: 'resume title'
+                                                           },
+                                                           cover_letter: {
+                                                             cover_letter_id: 'cover letter id',
+                                                             cover_letter_text: 'cover letter text',
+                                                             cover_letter_title: 'cover letter title'
+                                                           },
+                                                           responses: [
+                                                             {
+                                                               question_id: 1,
+                                                               response_text: 'hello 1' },
+                                                             {
+                                                               question_id: 2,
+                                                               response_text: 'hello 2' },
+                                                             {
+                                                               question_id: 3,
+                                                               response_text: 'hello 3'
+                                                             }
+                                                           ],
+                                                           test: true)
         end
 
         it 'should be correctly configured' do
@@ -97,11 +102,9 @@ module Cb
         end
 
         it 'should have basic headers' do
-          expect(@request.headers).to eq({
-            'DeveloperKey' => Cb.configuration.dev_key,
-            'HostSite' => Cb.configuration.host_site,
-            'Content-Type' => 'application/json'
-          })
+          expect(@request.headers).to eq('DeveloperKey' => Cb.configuration.dev_key,
+                                         'HostSite' => Cb.configuration.host_site,
+                                         'Content-Type' => 'application/json')
         end
 
         it 'should have a basic body' do
@@ -149,6 +152,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/application_external/submit_application_spec.rb
+++ b/spec/cb/requests/application_external/submit_application_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::ApplicationExternal::SubmitApplication do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::ApplicationExternal::SubmitApplication.new({}) }
@@ -38,15 +47,13 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::ApplicationExternal::SubmitApplication.new({
-            host_site: 'host site',
-            email_address: 'email address',
-            job_did: 'job did',
-            site_id: 'site id',
-            ipath: 'ipath id over length of 10',
-            is_external_link_apply: 'is external link apply',
-            sid: 'session id'
-          })
+          @request = Cb::Requests::ApplicationExternal::SubmitApplication.new(host_site: 'host site',
+                                                                              email_address: 'email address',
+                                                                              job_did: 'job did',
+                                                                              site_id: 'site id',
+                                                                              ipath: 'ipath id over length of 10',
+                                                                              is_external_link_apply: 'is external link apply',
+                                                                              sid: 'session id')
         end
 
         it 'should be correctly configured' do
@@ -78,6 +85,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/base_spec.rb
+++ b/spec/cb/requests/base_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::Base do
-
     context 'initialize' do
       it 'should have unimplemented errors' do
         base = Cb::Requests::Base.new({})
@@ -13,6 +22,5 @@ module Cb
         expect { Cb::Requests::Base.new('') }.to raise_error(ArgumentError)
       end
     end
-
   end
 end

--- a/spec/cb/requests/category/search_spec.rb
+++ b/spec/cb/requests/category/search_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::Category::Search do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::Category::Search.new({}) }
@@ -13,9 +22,7 @@ module Cb
         end
 
         it 'should have a basic query string' do
-          expect(@request.query).to eq({
-            CountryCode: nil
-          })
+          expect(@request.query).to eq(CountryCode: nil)
         end
 
         it 'should have basic headers' do
@@ -29,9 +36,7 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::Category::Search.new({
-            host_site: 'Hello'
-          })
+          @request = Cb::Requests::Category::Search.new(host_site: 'Hello')
         end
 
         it 'should be correctly configured' do
@@ -40,9 +45,7 @@ module Cb
         end
 
         it 'should have a basic query string' do
-          expect(@request.query).to eq({
-            CountryCode: "Hello"
-          })
+          expect(@request.query).to eq(CountryCode: 'Hello')
         end
 
         it 'should have basic headers' do
@@ -54,6 +57,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/company/find_spec.rb
+++ b/spec/cb/requests/company/find_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::Company::Find do
-
     describe '#new' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::Company::Find.new({}) }
@@ -13,7 +22,7 @@ module Cb
         end
 
         it 'should have a basic query string' do
-          expect(@request.query).to eq ({:CompanyDID => nil, :HostSite=> Cb.configuration.host_site})
+          expect(@request.query).to eq ({ CompanyDID: nil, HostSite: Cb.configuration.host_site })
         end
 
         it 'should have basic headers' do
@@ -27,9 +36,7 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::Company::Find.new({
-            did: "hello"
-          })
+          @request = Cb::Requests::Company::Find.new(did: 'hello')
         end
 
         it 'should be correctly configured' do
@@ -38,7 +45,7 @@ module Cb
         end
 
         it 'should have a basic query string' do
-          expect(@request.query).to eq ({:CompanyDID => "hello", :HostSite=> Cb.configuration.host_site})
+          expect(@request.query).to eq ({ CompanyDID: 'hello', HostSite: Cb.configuration.host_site })
         end
 
         it 'should have basic headers' do
@@ -50,6 +57,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/data_lists/countries_spec.rb
+++ b/spec/cb/requests/data_lists/countries_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -22,7 +32,7 @@ module Cb
         subject.get
       end
 
-      it { expect(subject.api_uri).to eq '/consumer/datalist/countries'}
+      it { expect(subject.api_uri).to eq '/consumer/datalist/countries' }
       it { expect(token).to receive(:get).with(uri) }
 
       context 'when country code is set' do

--- a/spec/cb/requests/data_lists/data_list_base_spec.rb
+++ b/spec/cb/requests/data_lists/data_list_base_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -6,7 +16,7 @@ module Cb
       describe DataListBase do
         let(:base) { Cb::Requests::DataLists::DataListBase }
         let(:token) { double('3Scale_token') }
-        let(:args) { {'countrycode' => 'GR' } }
+        let(:args) { { 'countrycode' => 'GR' } }
         let(:made_base) { base.new(token, args) }
         let(:uri) { 'https://api.careerbuilder.com/url_piece?countrycode=GR' }
 
@@ -38,7 +48,7 @@ module Cb
         end
 
         describe 'api_uri' do
-          it { expect{ made_base.api_uri }.to raise_error(NotImplementedError) }
+          it { expect { made_base.api_uri }.to raise_error(NotImplementedError) }
         end
       end
     end

--- a/spec/cb/requests/data_lists/desired_job_type_spec.rb
+++ b/spec/cb/requests/data_lists/desired_job_type_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -29,7 +39,7 @@ module Cb
         let(:uri) { 'https://api.careerbuilder.com/consumer/datalist/desiredjobtype?countrycode=GR' }
 
         it { expect(token).to receive(:get).with(uri) }
-        it { expect(subject.api_uri).to eq '/consumer/datalist/desiredjobtype'}
+        it { expect(subject.api_uri).to eq '/consumer/datalist/desiredjobtype' }
       end
     end
   end

--- a/spec/cb/requests/data_lists/languages_spec.rb
+++ b/spec/cb/requests/data_lists/languages_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -22,7 +32,7 @@ module Cb
         subject.get
       end
 
-      it { expect(subject.api_uri).to eq '/consumer/datalist/languages'}
+      it { expect(subject.api_uri).to eq '/consumer/datalist/languages' }
       it { expect(token).to receive(:get).with(uri) }
 
       context 'when country code is set' do

--- a/spec/cb/requests/data_lists/resume_education_spec.rb
+++ b/spec/cb/requests/data_lists/resume_education_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb

--- a/spec/cb/requests/data_lists/state_spec.rb
+++ b/spec/cb/requests/data_lists/state_spec.rb
@@ -1,35 +1,44 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::State::Get do
     describe '#new' do
-
       context 'without arguments' do
         let(:request) { Cb::Requests::State::Get.new({}) }
-        let(:query){
+        let(:query) do
           {
-              countryCode: nil,
-              outputjson: true
+            countryCode: nil,
+            outputjson: true
           }
-        }
+        end
 
         it { expect(request.endpoint_uri).to eq Cb.configuration.uri_state_list }
         it { expect(request.http_method).to eq :get }
         it { expect(request.query).to eq(query) }
         it { expect(request.body).to eq nil }
-        it { expect(request.base_uri).to eq 'https://www.careerbuilder.com'}
+        it { expect(request.base_uri).to eq 'https://www.careerbuilder.com' }
       end
 
       context 'with arguments' do
         let (:request) do
-          Cb::Requests::State::Get.new({ country_code: 'GR' })
+          Cb::Requests::State::Get.new(country_code: 'GR')
         end
-        let(:query){
+        let(:query) do
           {
-              countryCode: 'GR',
-              outputjson: true
+            countryCode: 'GR',
+            outputjson: true
           }
-        }
+        end
 
         it { expect(request.endpoint_uri).to eq(Cb.configuration.uri_state_list) }
         it { expect(request.http_method).to eq :get }

--- a/spec/cb/requests/education/get_spec.rb
+++ b/spec/cb/requests/education/get_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::Education::Get do
-
     describe '#new' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::Education::Get.new({}) }
@@ -13,7 +22,7 @@ module Cb
         end
 
         it 'should have a basic query string' do
-          expect(@request.query).to eq ({CountryCode: nil})
+          expect(@request.query).to eq ({ CountryCode: nil })
         end
 
         it 'should have basic headers' do
@@ -27,9 +36,7 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::Education::Get.new({
-            country_code: 'Hello'
-          })
+          @request = Cb::Requests::Education::Get.new(country_code: 'Hello')
         end
 
         it 'should be correctly configured' do
@@ -38,7 +45,7 @@ module Cb
         end
 
         it 'should have a basic query string' do
-          expect(@request.query).to eq ({CountryCode: "Hello"})
+          expect(@request.query).to eq ({ CountryCode: 'Hello' })
         end
 
         it 'should have basic headers' do

--- a/spec/cb/requests/email_subscription/modify_spec.rb
+++ b/spec/cb/requests/email_subscription/modify_spec.rb
@@ -32,7 +32,7 @@ module Cb
         it 'should have a basic body' do
           expect(@request.body).to eq <<eos
 <Request>
-<DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
+<DeveloperKey>#{ Cb.configuration.dev_key }</DeveloperKey>
 <ExternalID></ExternalID>
 <Hostsite></Hostsite>
 <CareerResources></CareerResources>

--- a/spec/cb/requests/email_subscription/modify_spec.rb
+++ b/spec/cb/requests/email_subscription/modify_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::EmailSubscription::Modify do
-
     describe '#new' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::EmailSubscription::Modify.new({}) }
@@ -23,7 +32,7 @@ module Cb
         it 'should have a basic body' do
           expect(@request.body).to eq <<eos
 <Request>
-<DeveloperKey>#{Cb.configuration.dev_key.to_s}</DeveloperKey>
+<DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
 <ExternalID></ExternalID>
 <Hostsite></Hostsite>
 <CareerResources></CareerResources>
@@ -41,18 +50,16 @@ eos
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::EmailSubscription::Modify.new({
-            external_id: 'external id',
-            host_site: 'host site',
-            career_resources: 'career resources',
-            product_sponsor_info: 'product sponsor info',
-            applicant_survey_invites: 'applicant survey invites',
-            job_recs: 'job recs',
-            djr: 'djr',
-            resume_viewed: 'resume viewed',
-            application_viewed: 'application viewed',
-            unsubscribe_all: 'unsubscribe all'
-          })
+          @request = Cb::Requests::EmailSubscription::Modify.new(external_id: 'external id',
+                                                                 host_site: 'host site',
+                                                                 career_resources: 'career resources',
+                                                                 product_sponsor_info: 'product sponsor info',
+                                                                 applicant_survey_invites: 'applicant survey invites',
+                                                                 job_recs: 'job recs',
+                                                                 djr: 'djr',
+                                                                 resume_viewed: 'resume viewed',
+                                                                 application_viewed: 'application viewed',
+                                                                 unsubscribe_all: 'unsubscribe all')
         end
 
         it 'should be correctly configured' do
@@ -71,7 +78,7 @@ eos
         it 'should have a basic body' do
           expect(@request.body).to eq <<eos
 <Request>
-<DeveloperKey>#{Cb.configuration.dev_key.to_s}</DeveloperKey>
+<DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
 <ExternalID>external id</ExternalID>
 <Hostsite>host site</Hostsite>
 <CareerResources>career resources</CareerResources>
@@ -89,18 +96,16 @@ eos
 
       context 'ensure unsubscribe all works' do
         before :each do
-          @request = Cb::Requests::EmailSubscription::Modify.new({
-            external_id: 'external id',
-            host_site: 'host site',
-            career_resources: 'career resources',
-            product_sponsor_info: 'product sponsor info',
-            applicant_survey_invites: 'applicant survey invites',
-            job_recs: 'job recs',
-            djr: 'djr',
-            resume_viewed: 'resume viewed',
-            application_viewed: 'application viewed',
-            unsubscribe_all: 'true'
-          })
+          @request = Cb::Requests::EmailSubscription::Modify.new(external_id: 'external id',
+                                                                 host_site: 'host site',
+                                                                 career_resources: 'career resources',
+                                                                 product_sponsor_info: 'product sponsor info',
+                                                                 applicant_survey_invites: 'applicant survey invites',
+                                                                 job_recs: 'job recs',
+                                                                 djr: 'djr',
+                                                                 resume_viewed: 'resume viewed',
+                                                                 application_viewed: 'application viewed',
+                                                                 unsubscribe_all: 'true')
         end
 
         it 'should be correctly configured' do
@@ -119,7 +124,7 @@ eos
         it 'should have a basic body' do
           expect(@request.body).to eq <<eos
 <Request>
-<DeveloperKey>#{Cb.configuration.dev_key.to_s}</DeveloperKey>
+<DeveloperKey>#{Cb.configuration.dev_key}</DeveloperKey>
 <ExternalID>external id</ExternalID>
 <Hostsite>host site</Hostsite>
 <CareerResources>false</CareerResources>

--- a/spec/cb/requests/email_subscription/retrieve_spec.rb
+++ b/spec/cb/requests/email_subscription/retrieve_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::EmailSubscription::Retrieve do
-
     describe '#new' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::EmailSubscription::Retrieve.new({}) }
@@ -14,10 +23,8 @@ module Cb
 
         it 'should have a basic query string' do
           expect(@request.query).to eq(
-            {
-              :ExternalID => nil,
-              :HostSite => nil
-            }
+            ExternalID: nil,
+            HostSite: nil
           )
         end
 
@@ -32,10 +39,8 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::EmailSubscription::Retrieve.new({
-            host_site: 'host site',
-            external_id: 'external id'
-          })
+          @request = Cb::Requests::EmailSubscription::Retrieve.new(host_site: 'host site',
+                                                                   external_id: 'external id')
         end
 
         it 'should be correctly configured' do
@@ -45,10 +50,8 @@ module Cb
 
         it 'should have a basic query string' do
           expect(@request.query).to eq(
-            {
-              :ExternalID => "external id",
-              :HostSite => "host site"
-            }
+            ExternalID: 'external id',
+            HostSite: 'host site'
           )
         end
 

--- a/spec/cb/requests/recommendations/resume_rec_spec.rb
+++ b/spec/cb/requests/recommendations/resume_rec_spec.rb
@@ -1,40 +1,50 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::Recommendations::Resume do
     describe '#new' do
-      let(:headers) {
+      let(:headers) do
         {
           'DeveloperKey' => Cb.configuration.dev_key,
           'HostSite' => Cb.configuration.host_site,
           'Content-Type' => 'application/json'
         }
-      }
+      end
       context 'without arguments' do
         let(:request) { Cb::Requests::Recommendations::Resume.new({}) }
 
         it { expect(request.endpoint_uri).to eq Cb.configuration.uri_recommendation_for_resume.sub(':resume_hash', '') }
         it { expect(request.http_method).to eq :get }
-        it { expect(request.query).to eq({ externalID: nil, countLimit: 25 }) }
+        it { expect(request.query).to eq(externalID: nil, countLimit: 25) }
         it { expect(request.body).to eq nil }
         it { expect(request.headers).to eq (headers) }
       end
 
       context 'with arguments' do
         let (:request) do
-          Cb::Requests::Recommendations::Resume.new({ resume_hash: 'resumeHash', external_user_id: 'externalUserId' })
+          Cb::Requests::Recommendations::Resume.new(resume_hash: 'resumeHash', external_user_id: 'externalUserId')
         end
 
         it { expect(request.endpoint_uri).to eq Cb.configuration.uri_recommendation_for_resume.sub(':resume_hash', 'resumeHash') }
         it { expect(request.http_method).to eq :get }
-        it { expect(request.query).to eq({ externalID: 'externalUserId', countLimit: 25 }) }
+        it { expect(request.query).to eq(externalID: 'externalUserId', countLimit: 25) }
         it { expect(request.body).to eq nil }
         it { expect(request.headers).to eq (headers) }
       end
 
       context 'when count limit is passed as argument' do
         let (:request) do
-          Cb::Requests::Recommendations::Resume.new({ resume_hash: 'resumeHash', external_user_id: 'externalUserId', countLimit: 50 })
+          Cb::Requests::Recommendations::Resume.new(resume_hash: 'resumeHash', external_user_id: 'externalUserId', countLimit: 50)
         end
 
         it { expect(request.query).to eq ({ externalID: 'externalUserId', countLimit: 50 }) }

--- a/spec/cb/requests/resumes/delete_spec.rb
+++ b/spec/cb/requests/resumes/delete_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::Resumes::Delete do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         let(:request) { Cb::Requests::Resumes::Delete.new({}) }
@@ -13,15 +22,13 @@ module Cb
         end
 
         it 'will have a basic query string' do
-          expect(request.query).to eq({ externalUserID: nil })
+          expect(request.query).to eq(externalUserID: nil)
         end
 
         it 'will have basic headers' do
-          expect(request.headers).to eq({
-              'DeveloperKey' => Cb.configuration.dev_key,
-              'HostSite' => Cb.configuration.host_site,
-              'Content-Type' => 'application/json;version=1.0'
-          })
+          expect(request.headers).to eq('DeveloperKey' => Cb.configuration.dev_key,
+                                        'HostSite' => Cb.configuration.host_site,
+                                        'Content-Type' => 'application/json;version=1.0')
         end
 
         it 'will have a basic body' do
@@ -31,7 +38,6 @@ module Cb
 
       context 'with arguments' do
         let(:request) { Cb::Requests::Resumes::Delete.new(resume_hash: 'resumeHash', external_user_id: 'externalUserId') }
-
 
         it 'will be correctly configured' do
           expect(request.endpoint_uri).to eq(Cb.configuration.uri_resume_get.sub(':resume_hash', 'resumeHash'))
@@ -43,11 +49,9 @@ module Cb
         end
 
         it 'will have basic headers' do
-          expect(request.headers).to eq({
-              'DeveloperKey' => Cb.configuration.dev_key,
-              'HostSite' => Cb.configuration.host_site,
-              'Content-Type' => 'application/json;version=1.0'
-          })
+          expect(request.headers).to eq('DeveloperKey' => Cb.configuration.dev_key,
+                                        'HostSite' => Cb.configuration.host_site,
+                                        'Content-Type' => 'application/json;version=1.0')
         end
 
         it 'will have a basic body' do
@@ -55,6 +59,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/resumes/get_spec.rb
+++ b/spec/cb/requests/resumes/get_spec.rb
@@ -1,28 +1,38 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::Resumes::Get do
-    let(:headers) {
+    let(:headers) do
       {
         'DeveloperKey' => Cb.configuration.dev_key,
         'HostSite' => Cb.configuration.host_site,
         'Content-Type' => 'application/json;version=1.0'
       }
-    }
+    end
     describe '#new' do
       context 'without arguments' do
         let(:request) { Cb::Requests::Resumes::Get.new({}) }
 
         it { expect(request.endpoint_uri).to eq Cb.configuration.uri_resume_get.sub(':resume_hash', '') }
         it { expect(request.http_method).to eq :get }
-        it { expect(request.query).to eq({ externalUserID: nil }) }
+        it { expect(request.query).to eq(externalUserID: nil) }
         it { expect(request.headers).to eq headers }
         it { expect(request.body).to eq nil }
       end
 
       context 'with arguments' do
         let (:request) do
-          Cb::Requests::Resumes::Get.new({ resume_hash: 'resumeHash', external_user_id: 'externalUserId' })
+          Cb::Requests::Resumes::Get.new(resume_hash: 'resumeHash', external_user_id: 'externalUserId')
         end
 
         it { expect(request.endpoint_uri).to eq(Cb.configuration.uri_resume_get.sub(':resume_hash', 'resumeHash')) }

--- a/spec/cb/requests/resumes/language_codes_spec.rb
+++ b/spec/cb/requests/resumes/language_codes_spec.rb
@@ -1,17 +1,27 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::Resumes::LanguageCodes do
-    let(:headers) {
+    let(:headers) do
       {
-          'DeveloperKey' => Cb.configuration.dev_key,
-          'Content-Type' => 'application/json;version=1.0'
+        'DeveloperKey' => Cb.configuration.dev_key,
+        'Content-Type' => 'application/json;version=1.0'
       }
-    }
+    end
 
     describe '#new' do
       context 'without arguments' do
-        let(:args) {{}}
+        let(:args) { {} }
         let(:request) { Cb::Requests::Resumes::LanguageCodes.new(args) }
         let(:default_country_code) { 'US' }
 
@@ -23,7 +33,7 @@ module Cb
 
       context 'with arguments' do
         let (:country_code) { 'GR' }
-        let (:request) { Cb::Requests::Resumes::LanguageCodes.new({ countryCode: country_code }) }
+        let (:request) { Cb::Requests::Resumes::LanguageCodes.new(countryCode: country_code) }
 
         it { expect(request.endpoint_uri).to eq Cb.configuration.uri_resume_language_codes }
         it { expect(request.http_method).to eq :get }

--- a/spec/cb/requests/resumes/list_spec.rb
+++ b/spec/cb/requests/resumes/list_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::Resumes::List do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         let(:request) { Cb::Requests::Resumes::List.new({}) }
@@ -13,7 +22,7 @@ module Cb
         end
 
         it 'will have a basic query string' do
-          expect(request.query).to eq({ HostSite: Cb.configuration.host_site, OAuthToken: nil })
+          expect(request.query).to eq(HostSite: Cb.configuration.host_site, OAuthToken: nil)
         end
 
         it 'will have basic headers' do
@@ -26,7 +35,7 @@ module Cb
       end
 
       context 'with arguments' do
-        let(:request) { Cb::Requests::Resumes::List.new({ oauth_token: 'token' }) }
+        let(:request) { Cb::Requests::Resumes::List.new(oauth_token: 'token') }
 
         it 'will be correctly configured' do
           expect(request.endpoint_uri).to eq(Cb.configuration.uri_resume_list)
@@ -46,6 +55,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/resumes/post_spec.rb
+++ b/spec/cb/requests/resumes/post_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::Resumes::Post do
-
     let(:request) { Cb::Requests::Resumes::Post.new(args) }
     let(:headers) do
       {
@@ -13,14 +22,14 @@ module Cb
     end
 
     context 'initialize without arguments' do
-      let(:args) {{}}
+      let(:args) { {} }
       let(:body) do
         {
           desiredJobTitle: nil,
           privacySetting: nil,
           resumeFileData: nil,
           resumeFileName: nil,
-          hostSite: nil,
+          hostSite: nil
         }.to_json
       end
 
@@ -45,9 +54,9 @@ module Cb
 
       let(:headers) do
         {
-            'HostSite' => Cb.configuration.host_site,
-            'Content-Type' => 'application/json',
-            'Authorization' => 'Bearer token'
+          'HostSite' => Cb.configuration.host_site,
+          'Content-Type' => 'application/json',
+          'Authorization' => 'Bearer token'
         }
       end
 

--- a/spec/cb/requests/resumes/put_spec.rb
+++ b/spec/cb/requests/resumes/put_spec.rb
@@ -1,9 +1,18 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 require 'support/mocks/resume'
 
 module Cb
   describe Cb::Requests::Resumes::Put do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         let (:request) { Cb::Requests::Resumes::Put.new({}) }
@@ -19,11 +28,9 @@ module Cb
 
         it 'should have basic headers' do
           expect(request.headers).to eq(
-            {
-              'DeveloperKey' => Cb.configuration.dev_key,
-              'HostSite' => Cb.configuration.host_site,
-              'Content-Type' => 'application/json;version=1.0'
-            }
+            'DeveloperKey' => Cb.configuration.dev_key,
+            'HostSite' => Cb.configuration.host_site,
+            'Content-Type' => 'application/json;version=1.0'
           )
         end
 
@@ -45,11 +52,9 @@ module Cb
 
         it 'should have basic headers' do
           expect(@request.headers).to eq(
-            {
-              'DeveloperKey' => Cb.configuration.dev_key,
-              'HostSite' => Cb.configuration.host_site,
-              'Content-Type' => 'application/json;version=1.0'
-            }
+            'DeveloperKey' => Cb.configuration.dev_key,
+            'HostSite' => Cb.configuration.host_site,
+            'Content-Type' => 'application/json;version=1.0'
           )
         end
 

--- a/spec/cb/requests/user/change_password_spec.rb
+++ b/spec/cb/requests/user/change_password_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::User::ChangePassword do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::User::ChangePassword.new({}) }
@@ -35,12 +44,10 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::User::ChangePassword.new({
-            external_id: 'external id',
-            test: 'true',
-            old_password: 'old password',
-            new_password: 'new password'
-          })
+          @request = Cb::Requests::User::ChangePassword.new(external_id: 'external id',
+                                                            test: 'true',
+                                                            old_password: 'old password',
+                                                            new_password: 'new password')
         end
 
         it 'should be correctly configured' do
@@ -69,6 +76,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/user/check_existing_spec.rb
+++ b/spec/cb/requests/user/check_existing_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::User::CheckExisting do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::User::CheckExisting.new({}) }
@@ -34,10 +43,8 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::User::CheckExisting.new({
-            email: "email",
-            password: "password"
-          })
+          @request = Cb::Requests::User::CheckExisting.new(email: 'email',
+                                                           password: 'password')
         end
 
         it 'should be correctly configured' do
@@ -65,6 +72,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/user/delete_spec.rb
+++ b/spec/cb/requests/user/delete_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::User::Delete do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::User::Delete.new({}) }
@@ -34,11 +43,9 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::User::Delete.new({
-            external_id: 'external id',
-            test: 'true',
-            password: 'password'
-          })
+          @request = Cb::Requests::User::Delete.new(external_id: 'external id',
+                                                    test: 'true',
+                                                    password: 'password')
         end
 
         it 'should be correctly configured' do
@@ -66,6 +73,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/user/retrieve_spec.rb
+++ b/spec/cb/requests/user/retrieve_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::User::Retrieve do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::User::Retrieve.new({}) }
@@ -33,10 +42,8 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::User::Retrieve.new({
-            :external_id => 'external id',
-            :test => 'true'
-          })
+          @request = Cb::Requests::User::Retrieve.new(external_id: 'external id',
+                                                      test: 'true')
         end
 
         it 'should be correctly configured' do
@@ -63,6 +70,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/user/temporary_password_spec.rb
+++ b/spec/cb/requests/user/temporary_password_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Requests::User::TemporaryPassword do
-
     context 'initialize without arguments' do
       context 'without arguments' do
         before(:each) { @request = Cb::Requests::User::TemporaryPassword.new({}) }
@@ -13,7 +22,7 @@ module Cb
         end
 
         it 'should have a basic query string' do
-          expect(@request.query).to eq({'ExternalID' => nil})
+          expect(@request.query).to eq('ExternalID' => nil)
         end
 
         it 'should have basic headers' do
@@ -27,9 +36,7 @@ module Cb
 
       context 'with arguments' do
         before :each do
-          @request = Cb::Requests::User::TemporaryPassword.new({
-            external_id: 'external id'
-          })
+          @request = Cb::Requests::User::TemporaryPassword.new(external_id: 'external id')
         end
 
         it 'should be correctly configured' do
@@ -38,7 +45,7 @@ module Cb
         end
 
         it 'should have a basic query string' do
-          expect(@request.query).to eq({'ExternalID' => 'external id'})
+          expect(@request.query).to eq('ExternalID' => 'external id')
         end
 
         it 'should have basic headers' do
@@ -50,6 +57,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/requests/work_status/list_spec.rb
+++ b/spec/cb/requests/work_status/list_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -33,7 +43,7 @@ module Cb
         end
 
         it 'should have a basic query string' do
-          expect(request.query).to eq ({ HostSite: "US" })
+          expect(request.query).to eq ({ HostSite: 'US' })
         end
 
         it 'should have basic headers' do

--- a/spec/cb/responses/anonymous_saved_search/create_spec.rb
+++ b/spec/cb/responses/anonymous_saved_search/create_spec.rb
@@ -1,50 +1,60 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 module Cb
   describe Responses::AnonymousSavedSearch::Create do
     let(:json_hash) do
       {
-        "Errors" => [],
-        "Status" => "Success",
-        "ExternalID" => "testID",
-        "AnonymousSavedSearch" => {
-          "SearchName" => "search name",
-          "IsDailyEmail" => "true",
-          "DailyValue" => "",
-          "EmailAddress" => "email@example.com",
-          "CobrandCode" => "",
-          "SiteID" => "",
-          "HostSite" => "host site",
-          "SearchParameters" => {
-            "BooleanOperator" => "boolean operator",
-            "Category" => "",
-            "EducationCode" => "education code",
-            "EmpType" => "emp type",
-            "ExcludeCompanyNames" => "exclude company names",
-            "ExcludeJobTitles" => "exclude job titles",
-            "ExcludeKeywords" => "exclude keywords",
-            "ExcludeNational" => false,
-            "IndustryCodes" => "industry codes",
-            "JobTitle" => "job title",
-            "Keywords" => "jobs",
-            "Location" => "atlanta",
-            "OrderBy" => "order by",
-            "OrderDirection" => "order direction",
-            "PayHigh" => 100,
-            "PayInfoOnly" => false,
-            "PayLow" => 10,
-            "PostedWithin" => 3,
-            "Radius" => 50,
-            "SpecificEducation" => false,
-            "JCPositionLevel" => "",
-            "JCLocation" => "",
-            "JCAdvertiserflags" => "",
-            "JCJobNature" => "",
-            "JCSchools" => "",
-            "JobCategory" => "job category",
-            "Company" => "",
-            "City" => "",
-            "State" => "",
-            "Country" => nil
+        'Errors' => [],
+        'Status' => 'Success',
+        'ExternalID' => 'testID',
+        'AnonymousSavedSearch' => {
+          'SearchName' => 'search name',
+          'IsDailyEmail' => 'true',
+          'DailyValue' => '',
+          'EmailAddress' => 'email@example.com',
+          'CobrandCode' => '',
+          'SiteID' => '',
+          'HostSite' => 'host site',
+          'SearchParameters' => {
+            'BooleanOperator' => 'boolean operator',
+            'Category' => '',
+            'EducationCode' => 'education code',
+            'EmpType' => 'emp type',
+            'ExcludeCompanyNames' => 'exclude company names',
+            'ExcludeJobTitles' => 'exclude job titles',
+            'ExcludeKeywords' => 'exclude keywords',
+            'ExcludeNational' => false,
+            'IndustryCodes' => 'industry codes',
+            'JobTitle' => 'job title',
+            'Keywords' => 'jobs',
+            'Location' => 'atlanta',
+            'OrderBy' => 'order by',
+            'OrderDirection' => 'order direction',
+            'PayHigh' => 100,
+            'PayInfoOnly' => false,
+            'PayLow' => 10,
+            'PostedWithin' => 3,
+            'Radius' => 50,
+            'SpecificEducation' => false,
+            'JCPositionLevel' => '',
+            'JCLocation' => '',
+            'JCAdvertiserflags' => '',
+            'JCJobNature' => '',
+            'JCSchools' => '',
+            'JobCategory' => 'job category',
+            'Company' => '',
+            'City' => '',
+            'State' => '',
+            'Country' => nil
           }
         }
       }
@@ -60,7 +70,6 @@ module Cb
 
         expect(response.model.class).to eq(Cb::Models::SavedSearch)
       end
-
     end
   end
 end

--- a/spec/cb/responses/anonymous_saved_search/delete_spec.rb
+++ b/spec/cb/responses/anonymous_saved_search/delete_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 module Cb
   describe Responses::AnonymousSavedSearch::Delete do
@@ -15,9 +25,8 @@ module Cb
       it 'instantiates new model objects' do
         response = Responses::AnonymousSavedSearch::Delete.new(json_hash)
 
-        expect(response.response["Status"]).to eq('yay')
+        expect(response.response['Status']).to eq('yay')
       end
-
     end
   end
 end

--- a/spec/cb/responses/api_response_spec.rb
+++ b/spec/cb/responses/api_response_spec.rb
@@ -1,6 +1,15 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 module Cb
   describe Responses::ApiResponse do
-
     # This is meant to be an abstract class providing template methods for
     # subclasses to override. You probably won't be instantiating any of this
     # class - notice how many errors these specs look for.
@@ -15,44 +24,43 @@ module Cb
 
         context 'when called with an empty input hash' do
           it 'raises an error' do
-            expect { Responses::ApiResponse.new(Hash.new) }.to raise_error ApiResponseError
+            expect { Responses::ApiResponse.new({}) }.to raise_error ApiResponseError
           end
         end
       end
 
       context '#response' do
         it 'raises a NotImplementedError' do
-          expect { Responses::ApiResponse.new({:yay => 'yay'}).response }.to raise_error NotImplementedError
+          expect { Responses::ApiResponse.new(yay: 'yay').response }.to raise_error NotImplementedError
         end
       end
 
       context '#models' do
         it 'raises a NotImplementedError' do
-          expect { Responses::ApiResponse.new({:yay => 'yay'}).models }.to raise_error NotImplementedError
+          expect { Responses::ApiResponse.new(yay: 'yay').models }.to raise_error NotImplementedError
         end
       end
 
       context '#[]' do
         it 'raises a NotImplementedError' do
-          expect { Responses::ApiResponse.new({:yay => 'yay'})[:yay] }.to raise_error NotImplementedError
+          expect { Responses::ApiResponse.new(yay: 'yay')[:yay] }.to raise_error NotImplementedError
         end
       end
 
       context '#timing' do
         it 'raises a NotImplementedError' do
-          expect { Responses::ApiResponse.new({:yay => 'yay'}).timing }.to raise_error NotImplementedError
+          expect { Responses::ApiResponse.new(yay: 'yay').timing }.to raise_error NotImplementedError
         end
       end
 
       context '#errors' do
         it 'raises a NotImplementedError' do
-          expect { Responses::ApiResponse.new({:yay => 'yay'}).errors }.to raise_error NotImplementedError
+          expect { Responses::ApiResponse.new(yay: 'yay').errors }.to raise_error NotImplementedError
         end
       end
     end
 
     context 'when minimally overriden' do
-
       class BrokenDirtyResponse1 < Responses::ApiResponse
         def hash_containing_metadata
           response['ResponseStuff']
@@ -71,9 +79,9 @@ module Cb
         end
       end
 
-      let(:model_hashes) { [{ 'huzzah' => 'thangs'}] }
-      let(:valid_input_hash) { { 'ResponseStuff' => { 'stuff' => model_hashes} } }
-      let(:errored_input_hash) { { 'ResponseStuff' => { 'errors' => { 'error' => ['oh noes!', 'bah!']}, :stuff => model_hashes } } }
+      let(:model_hashes) { [{ 'huzzah' => 'thangs' }] }
+      let(:valid_input_hash) { { 'ResponseStuff' => { 'stuff' => model_hashes } } }
+      let(:errored_input_hash) { { 'ResponseStuff' => { 'errors' => { 'error' => ['oh noes!', 'bah!'] }, :stuff => model_hashes } } }
 
       context 'when the input hash has all fields and all methods overridden' do
         it '#new instantiates happily' do
@@ -120,9 +128,10 @@ module Cb
 
             # these methods have to be overriden or else we get NotImplemented errors
             def validate_api_hash; end
+
             def extract_models; end
           end
-          
+
           it 'metadata parsing does not occur' do
             expect(Responses::Metadata).not_to receive(:new)
             ResponseWithoutMetadataParsing.new(valid_input_hash)
@@ -160,7 +169,6 @@ module Cb
             end
           end
         end
-
       end
     end
   end

--- a/spec/cb/responses/application/application_form_spec.rb
+++ b/spec/cb/responses/application/application_form_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 describe Cb::Responses::ApplicationForm do
@@ -14,9 +24,9 @@ describe Cb::Responses::ApplicationForm do
     it 'raises an exception' do
       response_stub.delete('Results')
 
-      expect{Cb::Responses::ApplicationForm.new(response_stub)}.
-        to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
-          expect(ex.message).to include 'Results'
+      expect { Cb::Responses::ApplicationForm.new(response_stub) }
+        .to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
+        expect(ex.message).to include 'Results'
       end
     end
   end

--- a/spec/cb/responses/application/application_form_spec.rb
+++ b/spec/cb/responses/application/application_form_spec.rb
@@ -24,8 +24,8 @@ describe Cb::Responses::ApplicationForm do
     it 'raises an exception' do
       response_stub.delete('Results')
 
-      expect { Cb::Responses::ApplicationForm.new(response_stub) }
-        .to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
+      expect{Cb::Responses::ApplicationForm.new(response_stub)}.
+          to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
         expect(ex.message).to include 'Results'
       end
     end

--- a/spec/cb/responses/application_external/submit_application_spec.rb
+++ b/spec/cb/responses/application_external/submit_application_spec.rb
@@ -1,10 +1,20 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Responses::ApplicationExternal::SubmitApplication do
     let(:json_hash) do
       { 'Errors' => nil,
-        'ApplyUrl' => "website.com"
+        'ApplyUrl' => 'website.com'
       }
     end
 
@@ -16,9 +26,8 @@ module Cb
       it 'instantiates new model objects' do
         response = Responses::ApplicationExternal::SubmitApplication.new(json_hash)
 
-        expect(response.model.apply_url).to eq("website.com")
+        expect(response.model.apply_url).to eq('website.com')
       end
-
     end
   end
 end

--- a/spec/cb/responses/category/search_spec.rb
+++ b/spec/cb/responses/category/search_spec.rb
@@ -1,42 +1,52 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Responses::Category::Search do
     let(:json_hash) do
       {
-        "ResponseCategories" =>
-          {"Errors" => nil,
-           "CountryCode" => "US",
-           "TimeResponseSent" => "5/30/2014 11:14:59 AM",
-           "Categories" =>
-             {"Category" => [
+        'ResponseCategories' =>
+          { 'Errors' => nil,
+            'CountryCode' => 'US',
+            'TimeResponseSent' => '5/30/2014 11:14:59 AM',
+            'Categories' =>
+             { 'Category' => [
                {
-                "Code" => "JN001",
-                "Name" => {
-                 "@language" => "en-US",
-                 "#text" => "Accounting"
-                }},
-              {
-                "Code" => "JN002",
-                "Name" =>
-                  {
-                    "@language" => "en-US",
-                    "#text" => "Admin - Clerical"
-                }},
-              {
-                "Code" => "JN054",
-                "Name" =>
-                  {
-                    "@language" => "en-US",
-                    "#text" => "Automotive"
-                }},
-              {
-                "Code" => "JN038",
-                "Name" =>
-                  {
-                    "@language" => "en-US",
-                    "#text" => "Banking"
-                }}]
+                 'Code' => 'JN001',
+                 'Name' => {
+                   '@language' => 'en-US',
+                   '#text' => 'Accounting'
+                 } },
+               {
+                 'Code' => 'JN002',
+                 'Name' =>
+                   {
+                     '@language' => 'en-US',
+                     '#text' => 'Admin - Clerical'
+                   } },
+               {
+                 'Code' => 'JN054',
+                 'Name' =>
+                   {
+                     '@language' => 'en-US',
+                     '#text' => 'Automotive'
+                   } },
+               {
+                 'Code' => 'JN038',
+                 'Name' =>
+                   {
+                     '@language' => 'en-US',
+                     '#text' => 'Banking'
+                   } }]
              }
           }
       }
@@ -68,7 +78,6 @@ module Cb
         expect(models[3].name).to eq('Banking')
         expect(models[3].language).to eq('en-US')
       end
-
     end
   end
 end

--- a/spec/cb/responses/company/find_spec.rb
+++ b/spec/cb/responses/company/find_spec.rb
@@ -48,11 +48,14 @@ module Cb
             'Testimonials' => { 'Testimonials' => nil },
             'MyContent' => { 'MyContentTabs' => nil },
             'MyPhotos' => nil,
-            'InfoTabs' =>              { 'InfoTabs' =>                 { 'InfoTab' =>                    [{ 'Name' => 'Products',
-                                                                                                            'Content' => ''
-                    },
-                                                                                                          { 'Name' => 'Contact Us',
-                                                                                                            'Content' => '' }] } },
+            'InfoTabs'=>
+                {'InfoTabs'=>
+                     {'InfoTab'=>
+                          [{'Name'=>'Products',
+                            'Content'=> ''
+                           },
+                           {'Name'=>'Contact Us',
+                            'Content'=> ''}]}},
             'CompanyLinksCollection' => { 'companylinks' => nil },
             'CollegeLabel' => 'College',
             'CollegeBody' => nil,

--- a/spec/cb/responses/company/find_spec.rb
+++ b/spec/cb/responses/company/find_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 
 require 'spec_helper'
 
@@ -5,62 +15,59 @@ module Cb
   describe Responses::Company::Find do
     let(:json_hash) do
       {
-        "Results" => {
-          "CompanyProfileDetail" => {
-            "CompanyName"=>"Accountemps",
-            "CompanyDID"=>"CHT6P575L7RY61K1NPT",
-            "HHName"=>"AccountempsOct1",
-            "URL"=>"http://www.accountemps.com",
-            "ImageFile"=>nil,
-            "YearFounded"=>nil,
-            "FBPageURL"=>nil,
-            "CompanySize"=>"5,000 - 10,000",
-            "CompanyType"=>"Public",
-            "HeaderImage"=>nil,
-            "FooterImage"=>nil,
-            "TotalNumberJobs"=>"2294",
-            "Headquarter"=>nil,
-            "TabHeaderBGColor"=>nil,
-            "TabHeaderTextColor"=>nil,
-            "TabHeaderHoverColor"=>nil,
-            "SidebarHeaderColor"=>nil,
-            "ButtonColor"=>nil,
-            "ButtonTextColor"=>nil,
-            "GutterBGColor"=>nil,
-            "FacebookWidget"=>nil,
-            "TwitterWidget"=>nil,
-            "LinkedInWidget"=>nil,
-            "HostSites"=>nil,
-            "SDrive"=>nil,
-            "CompanyPhotos"=>{"PhotoList"=>nil},
-            "CompanyAddress"=>{"AddressList"=>nil},
-            "CompanyBulletinBoard"=>{"bulletinboards"=>nil},
-            "Testimonials"=>{"Testimonials"=>nil},
-            "MyContent"=>{"MyContentTabs"=>nil},
-            "MyPhotos"=>nil,
-            "InfoTabs"=>
-             {"InfoTabs"=>
-                {"InfoTab"=>
-                   [{"Name"=>"Products",
-                     "Content"=> ""
+        'Results' => {
+          'CompanyProfileDetail' => {
+            'CompanyName' => 'Accountemps',
+            'CompanyDID' => 'CHT6P575L7RY61K1NPT',
+            'HHName' => 'AccountempsOct1',
+            'URL' => 'http://www.accountemps.com',
+            'ImageFile' => nil,
+            'YearFounded' => nil,
+            'FBPageURL' => nil,
+            'CompanySize' => '5,000 - 10,000',
+            'CompanyType' => 'Public',
+            'HeaderImage' => nil,
+            'FooterImage' => nil,
+            'TotalNumberJobs' => '2294',
+            'Headquarter' => nil,
+            'TabHeaderBGColor' => nil,
+            'TabHeaderTextColor' => nil,
+            'TabHeaderHoverColor' => nil,
+            'SidebarHeaderColor' => nil,
+            'ButtonColor' => nil,
+            'ButtonTextColor' => nil,
+            'GutterBGColor' => nil,
+            'FacebookWidget' => nil,
+            'TwitterWidget' => nil,
+            'LinkedInWidget' => nil,
+            'HostSites' => nil,
+            'SDrive' => nil,
+            'CompanyPhotos' => { 'PhotoList' => nil },
+            'CompanyAddress' => { 'AddressList' => nil },
+            'CompanyBulletinBoard' => { 'bulletinboards' => nil },
+            'Testimonials' => { 'Testimonials' => nil },
+            'MyContent' => { 'MyContentTabs' => nil },
+            'MyPhotos' => nil,
+            'InfoTabs' =>              { 'InfoTabs' =>                 { 'InfoTab' =>                    [{ 'Name' => 'Products',
+                                                                                                            'Content' => ''
                     },
-                   {"Name"=>"Contact Us",
-                    "Content"=> ""}]}},
-            "CompanyLinksCollection"=>{"companylinks"=>nil},
-            "CollegeLabel"=>"College",
-            "CollegeBody"=>nil,
-            "DiversityLabel"=>"Diversity",
-            "DiversityBody"=>nil,
-            "PeopleLabel"=>"People",
-            "ContactLabel"=>"Contact",
-            "isEnhance"=>"false",
-            "MilitaryIcon"=>"false",
-            "PremiumProfile"=>"true",
-            "HasBenefits"=>"false",
-            "HasGallery"=>"false",
-            "HasSocialMedia"=>"false",
-            "HasVideo"=>"false",
-            "IndustryType"=>{"string"=>"Accounting - Finance"}}
+                                                                                                          { 'Name' => 'Contact Us',
+                                                                                                            'Content' => '' }] } },
+            'CompanyLinksCollection' => { 'companylinks' => nil },
+            'CollegeLabel' => 'College',
+            'CollegeBody' => nil,
+            'DiversityLabel' => 'Diversity',
+            'DiversityBody' => nil,
+            'PeopleLabel' => 'People',
+            'ContactLabel' => 'Contact',
+            'isEnhance' => 'false',
+            'MilitaryIcon' => 'false',
+            'PremiumProfile' => 'true',
+            'HasBenefits' => 'false',
+            'HasGallery' => 'false',
+            'HasSocialMedia' => 'false',
+            'HasVideo' => 'false',
+            'IndustryType' => { 'string' => 'Accounting - Finance' } }
         }
       }
     end
@@ -75,7 +82,6 @@ module Cb
 
         expect(response.model).to be_a Cb::Models::Company
       end
-
     end
   end
 end

--- a/spec/cb/responses/data_lists/data_list_response_spec.rb
+++ b/spec/cb/responses/data_lists/data_list_response_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -15,7 +25,7 @@ module Cb
         end
         it do
           expect { Cb::Responses::ResumeDataList.new(response_stub) }
-          .to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
+            .to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
             expect(ex.message).to include total_results
           end
         end
@@ -29,7 +39,7 @@ module Cb
         end
         it do
           expect { Cb::Responses::ResumeDataList.new(response_stub) }
-          .to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
+            .to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
             expect(ex.message).to include returned_results
           end
         end
@@ -38,7 +48,6 @@ module Cb
       it { expect(subject.model.first).to be_an_instance_of(Cb::Models::ResumeDataList) }
       it { expect(subject.model.first.key).to eql('ce3101') }
       it { expect(subject.model.first.value).to eql('Vocational High School') }
-
     end
   end
 end

--- a/spec/cb/responses/data_lists/data_list_response_spec.rb
+++ b/spec/cb/responses/data_lists/data_list_response_spec.rb
@@ -39,7 +39,7 @@ module Cb
         end
         it do
           expect { Cb::Responses::ResumeDataList.new(response_stub) }
-            .to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
+              .to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
             expect(ex.message).to include returned_results
           end
         end

--- a/spec/cb/responses/data_lists/state_spec.rb
+++ b/spec/cb/responses/data_lists/state_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb

--- a/spec/cb/responses/education/get_spec.rb
+++ b/spec/cb/responses/education/get_spec.rb
@@ -1,23 +1,33 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Responses::Education::Get do
     let(:json_hash) do
       {
-        "ResponseEducationCodes" => {
-          "Errors" => nil,
-          "CountryCode" => "US",
-          "TimeResponseSent" => "6/2/2014 10:32:44 AM",
-          "EducationCodes" => {
-            "Education" => [
+        'ResponseEducationCodes' => {
+          'Errors' => nil,
+          'CountryCode' => 'US',
+          'TimeResponseSent' => '6/2/2014 10:32:44 AM',
+          'EducationCodes' => {
+            'Education' => [
               {
-                "Code" => "DRNS","Name" => {"@language" => "en-US","#text" => "Not Specified"}
+                'Code' => 'DRNS', 'Name' => { '@language' => 'en-US', '#text' => 'Not Specified' }
               },
               {
-                "Code" => "DR3210","Name" => {"@language" => "en-US","#text" => "None"}
+                'Code' => 'DR3210', 'Name' => { '@language' => 'en-US', '#text' => 'None' }
               },
               {
-                "Code" => "DR3211","Name" => {"@language" => "en-US","#text" => "High School"}
+                'Code' => 'DR3211', 'Name' => { '@language' => 'en-US', '#text' => 'High School' }
               }
             ]
           }
@@ -49,7 +59,6 @@ module Cb
         expect(models[2].text).to eq('High School')
         expect(models[2].language).to eq('en-US')
       end
-
     end
   end
 end

--- a/spec/cb/responses/email_subscription/response_spec.rb
+++ b/spec/cb/responses/email_subscription/response_spec.rb
@@ -1,21 +1,31 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Responses::EmailSubscription::Response do
     let(:json_hash) do
       {
-        "Errors" => [],
-        "Status" => "Success",
-        "SubscriptionValues" => {
-            "CareerResources" => true,
-            "ProductSponsorInfo" => false,
-            "ApplicantSurveyInvites" => true,
-            "JobRecs" => true,
-            "DJR" => false,
-            "ResumeViewed" => true,
-            "ApplicationViewed" => false
-          }
+        'Errors' => [],
+        'Status' => 'Success',
+        'SubscriptionValues' => {
+          'CareerResources' => true,
+          'ProductSponsorInfo' => false,
+          'ApplicantSurveyInvites' => true,
+          'JobRecs' => true,
+          'DJR' => false,
+          'ResumeViewed' => true,
+          'ApplicationViewed' => false
         }
+      }
     end
 
     context '#new' do
@@ -36,7 +46,6 @@ module Cb
         expect(model.resume_viewed).to eq 'true'
         expect(model.application_viewed).to eq 'false'
       end
-
     end
   end
 end

--- a/spec/cb/responses/employee_types/search_spec.rb
+++ b/spec/cb/responses/employee_types/search_spec.rb
@@ -1,11 +1,21 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 module Cb
   describe Responses::EmployeeTypes::Search do
     let(:json_hash) do
       { 'ResponseEmployeeTypes' => {
-          'EmployeeTypes' => {
-            'EmployeeType' => [{'whoa' => 'nelly'}]
-          }
+        'EmployeeTypes' => {
+          'EmployeeType' => [{ 'whoa' => 'nelly' }]
         }
+      }
       }
     end
 
@@ -30,7 +40,7 @@ module Cb
         end
 
         context 'missing root node' do
-          let(:json_hash) do { 'yey' => 'wow' } end
+          let(:json_hash) { { 'yey' => 'wow' } }
 
           it 'raises an error' do
             expect_response_field_error
@@ -38,7 +48,7 @@ module Cb
         end
 
         context 'missing EmployeeTypes node' do
-          let(:json_hash) do { 'ResponseEmployeeTypes' => Hash.new } end
+          let(:json_hash) { { 'ResponseEmployeeTypes' => {} } }
 
           it 'raises an error' do
             expect_response_field_error
@@ -46,7 +56,7 @@ module Cb
         end
 
         context 'missing EmployeeType node' do
-          let(:json_hash) do { 'ResponseEmployeeTypes' => { 'EmployeeTypes' => Hash.new } } end
+          let(:json_hash) { { 'ResponseEmployeeTypes' => { 'EmployeeTypes' => {} } } }
 
           it 'raises an error' do
             expect_response_field_error

--- a/spec/cb/responses/employee_types/search_spec.rb
+++ b/spec/cb/responses/employee_types/search_spec.rb
@@ -14,8 +14,8 @@ module Cb
       { 'ResponseEmployeeTypes' => {
         'EmployeeTypes' => {
           'EmployeeType' => [{ 'whoa' => 'nelly' }]
+          }
         }
-      }
       }
     end
 

--- a/spec/cb/responses/errors_spec.rb
+++ b/spec/cb/responses/errors_spec.rb
@@ -1,9 +1,18 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 module Cb
   describe Responses::Errors do
-    before(:all) do @errors = ['much awesome', 'so api', 'wow'] end
+    before(:all) { @errors = ['much awesome', 'so api', 'wow'] }
 
     context '#new' do
-
       let(:parsed_error_response) { 'much awesome,so api,wow' }
 
       def self.run_specs
@@ -35,17 +44,17 @@ module Cb
       end
 
       context 'when passed a hash with "errors" node as a hash' do
-        before(:all) do @errors_hash = { 'errors' => { 'error' => @errors } } end
+        before(:all) { @errors_hash = { 'errors' => { 'error' => @errors } } }
         run_specs
       end
 
       context 'when passed a hash with "error" node as an array' do
-        before(:all) do @errors_hash =  { 'error' => @errors } end
+        before(:all) { @errors_hash =  { 'error' => @errors } }
         run_specs
       end
     end
 
-    before(:all) do @errors_hash = { 'errors' => { 'error' => @errors } } end
+    before(:all) { @errors_hash = { 'errors' => { 'error' => @errors } } }
 
     context '#parsed' do
       it 'returns an enumerable of strings' do
@@ -65,6 +74,5 @@ module Cb
         errors.pop
       end
     end
-
   end
 end

--- a/spec/cb/responses/industry/search_spec.rb
+++ b/spec/cb/responses/industry/search_spec.rb
@@ -1,10 +1,20 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 module Cb
   describe Responses::Industry::Search do
     let(:response) do
       { 'ResponseIndustryCodes' => {
-          'IndustryCodes' => {
-              'IndustryCode' => [{'like' => 'whoa'}]
-          }
+        'IndustryCodes' => {
+          'IndustryCode' => [{ 'like' => 'whoa' }]
+        }
       }
       }
     end
@@ -30,7 +40,7 @@ module Cb
         end
 
         context 'missing root node' do
-          let(:response) do { 'herp' => 'derp' } end
+          let(:response) { { 'herp' => 'derp' } }
 
           it 'raises an error' do
             expect_response_field_error
@@ -38,7 +48,7 @@ module Cb
         end
 
         context 'missing IndustryCodes node' do
-          let(:response) do { 'ResponseIndustryCodes' => Hash.new } end
+          let(:response) { { 'ResponseIndustryCodes' => {} } }
 
           it 'raises an error' do
             expect_response_field_error
@@ -46,7 +56,7 @@ module Cb
         end
 
         context 'missing IndustryCode node' do
-          let(:response) do { 'ResponseIndustryCodes' => { 'IndustryCodes' => Hash.new } } end
+          let(:response) { { 'ResponseIndustryCodes' => { 'IndustryCodes' => {} } } }
 
           it 'raises an error' do
             expect_response_field_error

--- a/spec/cb/responses/job/search_v3_spec.rb
+++ b/spec/cb/responses/job/search_v3_spec.rb
@@ -1,28 +1,33 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 describe Cb::Responses::Job::SearchV3 do
-  
   shared_examples 'search_v3_response' do |example_response_file|
-
     let(:search_response_hash) { YAML.load open(example_response_file) }
     let(:search_results) { described_class.new(search_response_hash) }
 
     describe '#model' do
-    
       it 'returns a JobResultsV3' do
-        expect(search_results.model).to be_instance_of(Cb::Models::JobResultsV3) 
+        expect(search_results.model).to be_instance_of(Cb::Models::JobResultsV3)
       end
     end
-  
+
     describe '#response' do
-    
       it 'returns a hash' do
         expect(search_results.response).to be_instance_of(Hash)
       end
     end
   end
-  
-  it_behaves_like "search_v3_response", 'spec/support/response_stubs/search_result_v3.yml'
-  it_behaves_like "search_v3_response", 'spec/support/response_stubs/company_colapse_search_result_v3.yml'
 
+  it_behaves_like 'search_v3_response', 'spec/support/response_stubs/search_result_v3.yml'
+  it_behaves_like 'search_v3_response', 'spec/support/response_stubs/company_colapse_search_result_v3.yml'
 end

--- a/spec/cb/responses/metadata_spec.rb
+++ b/spec/cb/responses/metadata_spec.rb
@@ -1,6 +1,15 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 module Cb
   describe Responses::Metadata do
-
     context '#new' do
       let(:valid_input) { Hash.new } # valid input must act like a hash!
 
@@ -14,6 +23,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/responses/recommendations/resume_recs_spec.rb
+++ b/spec/cb/responses/recommendations/resume_recs_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 describe Cb::Responses::Recommendations do
@@ -7,7 +17,7 @@ describe Cb::Responses::Recommendations do
   it { expect(api_job_result_collection.models.first).to be_an_instance_of Cb::Models::RecommendedJob }
 
   describe '#root_node' do
-    it { expect(api_job_result_collection.root_node).to eq('data')}
+    it { expect(api_job_result_collection.root_node).to eq('data') }
   end
 
   context 'when the Api response is missing the results field' do
@@ -15,7 +25,7 @@ describe Cb::Responses::Recommendations do
     let(:response) { Cb::Responses::Recommendations.new(response_missing_data_node) }
 
     it 'raises an exception' do
-      expect{ response }.to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
+      expect { response }.to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
         expect(ex.message).to include 'data'
       end
     end

--- a/spec/cb/responses/resumes/language_codes_spec.rb
+++ b/spec/cb/responses/resumes/language_codes_spec.rb
@@ -35,8 +35,8 @@ module Cb
           response_stub['ResponseLanguageCodes']['LanguageCodes'].delete('LanguageCode')
         end
         it do
-          expect { Cb::Responses::LanguageCodes.new(response_stub) }
-            .to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
+          expect {Cb::Responses::LanguageCodes.new(response_stub)}.
+              to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
             expect(ex.message).to include 'LanguageCode'
           end
         end

--- a/spec/cb/responses/resumes/language_codes_spec.rb
+++ b/spec/cb/responses/resumes/language_codes_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
@@ -13,8 +23,8 @@ module Cb
           response_stub['ResponseLanguageCodes'].delete('LanguageCodes')
         end
         it do
-          expect {Cb::Responses::LanguageCodes.new(response_stub)}.
-            to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
+          expect { Cb::Responses::LanguageCodes.new(response_stub) }
+            .to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
             expect(ex.message).to include 'LanguageCodes'
           end
         end
@@ -25,8 +35,8 @@ module Cb
           response_stub['ResponseLanguageCodes']['LanguageCodes'].delete('LanguageCode')
         end
         it do
-          expect {Cb::Responses::LanguageCodes.new(response_stub)}.
-              to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
+          expect { Cb::Responses::LanguageCodes.new(response_stub) }
+            .to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
             expect(ex.message).to include 'LanguageCode'
           end
         end

--- a/spec/cb/responses/resumes/resume_list_spec.rb
+++ b/spec/cb/responses/resumes/resume_list_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 describe Cb::Responses::ResumeList do
@@ -11,8 +21,8 @@ describe Cb::Responses::ResumeList do
   context 'when the Api response is missing the results field' do
     it 'raises an exception' do
       response.delete('Resumes')
-      expect{ Cb::Responses::ResumeList.new(response) }.
-          to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
+      expect { Cb::Responses::ResumeList.new(response) }
+        .to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
         expect(ex.message).to include 'Resumes'
       end
     end

--- a/spec/cb/responses/resumes/resume_list_spec.rb
+++ b/spec/cb/responses/resumes/resume_list_spec.rb
@@ -21,8 +21,8 @@ describe Cb::Responses::ResumeList do
   context 'when the Api response is missing the results field' do
     it 'raises an exception' do
       response.delete('Resumes')
-      expect { Cb::Responses::ResumeList.new(response) }
-        .to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
+      expect { Cb::Responses::ResumeList.new(response) }.
+        to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
         expect(ex.message).to include 'Resumes'
       end
     end

--- a/spec/cb/responses/resumes/resume_spec.rb
+++ b/spec/cb/responses/resumes/resume_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 describe Cb::Responses::Resume do
@@ -14,9 +24,9 @@ describe Cb::Responses::Resume do
   context 'when the Api response is missing the results field' do
     it 'raises an exception' do
       response.delete('Results')
-      expect{ Cb::Responses::Resume.new(response) }.
-        to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
-          expect(ex.message).to include 'Results'
+      expect { Cb::Responses::Resume.new(response) }
+        .to raise_error(Cb::ExpectedResponseFieldMissing) do |ex|
+        expect(ex.message).to include 'Results'
       end
     end
   end

--- a/spec/cb/responses/timing_spec.rb
+++ b/spec/cb/responses/timing_spec.rb
@@ -1,7 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 module Cb
   describe Responses::Timing do
     let(:valid_input_hash) do
-      { 'TimeResponseSent' => "-4712-01-01T00:00:00+00:00", 'TimeElapsed' => '0.01337' }
+      { 'TimeResponseSent' => '-4712-01-01T00:00:00+00:00', 'TimeElapsed' => '0.01337' }
     end
 
     def valid_instance
@@ -63,6 +73,5 @@ module Cb
         end
       end
     end
-
   end
 end

--- a/spec/cb/responses/user/change_password_spec.rb
+++ b/spec/cb/responses/user/change_password_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'cb/responses/user/change_password'
 
 module Cb
@@ -19,11 +29,11 @@ module Cb
 
       context 'when input response hash cannot be validated due to' do
         context 'missing password node' do
-          let(:json_hash) do { 'yey' => 'wow' } end
+          let(:json_hash) { { 'yey' => 'wow' } }
 
           it 'raises an error' do
-            expect { Responses::User::ChangePassword.new(json_hash) }.
-                to raise_error ExpectedResponseFieldMissing
+            expect { Responses::User::ChangePassword.new(json_hash) }
+              .to raise_error ExpectedResponseFieldMissing
           end
         end
       end

--- a/spec/cb/responses/user/check_existing_spec.rb
+++ b/spec/cb/responses/user/check_existing_spec.rb
@@ -1,20 +1,30 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'cb/responses/user/check_existing'
 
 module Cb
   describe Responses::User::CheckExisting do
     let(:json_hash) do
       {
-          'Errors' => '',
-          'ResponseUserCheck' => {
-            'Request' => {
-                'Email' => "wut"
-            },
-            'UserCheckStatus' => 'walrus',
-            'ResponseExternalID' => '1',
-            'ResponseOAuthToken' => 'A',
-            'ResponsePartnerID' => '5',
-            'ResponseTempPassword' => 'false'
-          }
+        'Errors' => '',
+        'ResponseUserCheck' => {
+          'Request' => {
+            'Email' => 'wut'
+          },
+          'UserCheckStatus' => 'walrus',
+          'ResponseExternalID' => '1',
+          'ResponseOAuthToken' => 'A',
+          'ResponsePartnerID' => '5',
+          'ResponseTempPassword' => 'false'
+        }
       }
     end
 
@@ -25,11 +35,11 @@ module Cb
 
       context 'when input response hash cannot be validated due to' do
         context 'missing password node' do
-          let(:json_hash) do { 'yey' => 'wow' } end
+          let(:json_hash) { { 'yey' => 'wow' } }
 
           it 'raises an error' do
-            expect { Responses::User::CheckExisting.new(json_hash) }.
-              to raise_error ExpectedResponseFieldMissing
+            expect { Responses::User::CheckExisting.new(json_hash) }
+              .to raise_error ExpectedResponseFieldMissing
           end
         end
       end

--- a/spec/cb/responses/user/delete_spec.rb
+++ b/spec/cb/responses/user/delete_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'cb/responses/user/delete'
 
 module Cb
@@ -19,11 +29,11 @@ module Cb
 
       context 'when input response hash cannot be validated due to' do
         context 'missing password node' do
-          let(:json_hash) do { 'yey' => 'wow' } end
+          let(:json_hash) { { 'yey' => 'wow' } }
 
           it 'raises an error' do
-            expect { Responses::User::Delete.new(json_hash) }.
-              to raise_error ExpectedResponseFieldMissing
+            expect { Responses::User::Delete.new(json_hash) }
+              .to raise_error ExpectedResponseFieldMissing
           end
         end
       end

--- a/spec/cb/responses/user/retrieve_spec.rb
+++ b/spec/cb/responses/user/retrieve_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'cb/responses/user/retrieve'
 
 module Cb
@@ -6,7 +16,7 @@ module Cb
       {
         'Errors' => '',
         'ResponseUserInfo' => {
-            'Request' => "HEY"
+          'Request' => 'HEY'
         }
       }
     end
@@ -18,11 +28,11 @@ module Cb
 
       context 'when input response hash cannot be validated due to' do
         context 'missing password node' do
-          let(:json_hash) do { 'yey' => 'wow' } end
+          let(:json_hash) { { 'yey' => 'wow' } }
 
           it 'raises an error' do
-            expect { Responses::User::Retrieve.new(json_hash) }.
-              to raise_error ExpectedResponseFieldMissing
+            expect { Responses::User::Retrieve.new(json_hash) }
+              .to raise_error ExpectedResponseFieldMissing
           end
         end
       end

--- a/spec/cb/responses/user/temporary_password_spec.rb
+++ b/spec/cb/responses/user/temporary_password_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'cb/responses/user/temporary_password'
 
 module Cb
@@ -11,17 +21,17 @@ module Cb
 
     context '#new' do
       it 'returns a temp password response object' do
-        expect(Responses::User::TemporaryPassword.new(json_hash)).
-          to be_an_instance_of Responses::User::TemporaryPassword
+        expect(Responses::User::TemporaryPassword.new(json_hash))
+          .to be_an_instance_of Responses::User::TemporaryPassword
       end
 
       context 'when input response hash cannot be validated due to' do
         context 'missing password node' do
-          let(:json_hash) do { 'yey' => 'wow' } end
+          let(:json_hash) { { 'yey' => 'wow' } }
 
           it 'raises an error' do
-            expect { Responses::User::TemporaryPassword.new(json_hash) }.
-              to raise_error ExpectedResponseFieldMissing
+            expect { Responses::User::TemporaryPassword.new(json_hash) }
+              .to raise_error ExpectedResponseFieldMissing
           end
         end
       end

--- a/spec/cb/responses/work_status/list_spec.rb
+++ b/spec/cb/responses/work_status/list_spec.rb
@@ -1,25 +1,35 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Responses::WorkStatus::List do
     let(:json_hash) do
       {
-        "Errors" => nil,
-        "WorkStatuses" => [
+        'Errors' => nil,
+        'WorkStatuses' => [
           {
-            "Key" => "CTCT",
-            "Description" => [
+            'Key' => 'CTCT',
+            'Description' => [
               {
-                "Language" => "French",
-                "Value" => "Citoyen"
+                'Language' => 'French',
+                'Value' => 'Citoyen'
               },
               {
-                "Language" => "Dutch",
-                "Value" => "Inwoner"
+                'Language' => 'Dutch',
+                'Value' => 'Inwoner'
               },
               {
-                "Language" => "English",
-                "Value" => "US Citizen"
+                'Language' => 'English',
+                'Value' => 'US Citizen'
               }
             ]
           }

--- a/spec/cb/utils/api_spec.rb
+++ b/spec/cb/utils/api_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 require_relative '../../support/mocks/observer'
 module Cb
@@ -37,10 +47,10 @@ module Cb
 
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_get_before", '/moom', {},
+            expect(Cb::Models::ApiCall).to receive(:new).with(:cb_get_before, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
                                                               nil, 0.0).at_most(1).times.and_call_original
-            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_get_after", '/moom', {},
+            expect(Cb::Models::ApiCall).to receive(:new).with(:cb_get_after, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
                                                               { success: 'yeah' }, instance_of(Float)).at_most(1).times.and_call_original
             expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall)).at_most(2).times
@@ -89,10 +99,10 @@ module Cb
 
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_post_before", '/moom', {},
+            expect(Cb::Models::ApiCall).to receive(:new).with(:cb_post_before, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
                                                               nil, 0.0).at_most(1).times.and_call_original
-            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_post_after", '/moom', {},
+            expect(Cb::Models::ApiCall).to receive(:new).with(:cb_post_after, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
                                                               { success: 'yeah' }, instance_of(Float)).at_most(1).times.and_call_original
             expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall)).at_most(2).times
@@ -141,10 +151,10 @@ module Cb
 
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_put_before", '/moom', {},
+            expect(Cb::Models::ApiCall).to receive(:new).with(:cb_put_before, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
                                                               nil, 0.0).at_most(1).times.and_call_original
-            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_put_after", '/moom', {},
+            expect(Cb::Models::ApiCall).to receive(:new).with(:cb_put_after, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
                                                               { success: 'yeah' }, instance_of(Float)).at_most(1).times.and_call_original
             expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall)).at_most(2).times
@@ -194,10 +204,10 @@ module Cb
 
           it 'will notify the observers' do
             expect(api).to receive(:notify_observers).twice.and_call_original
-            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_delete_before", '/moom', {},
+            expect(Cb::Models::ApiCall).to receive(:new).with(:cb_delete_before, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
                                                               nil, 0.0).at_most(1).times.and_call_original
-            expect(Cb::Models::ApiCall).to receive(:new).with(:"cb_delete_after", '/moom', {},
+            expect(Cb::Models::ApiCall).to receive(:new).with(:cb_delete_after, '/moom', {},
                                                               { file: __FILE__, method: 'block (4 levels) in <module:Utils>' },
                                                               { success: 'yeah' }, instance_of(Float)).at_most(1).times.and_call_original
             expect(observer).to receive(:update).with(instance_of(Cb::Models::ApiCall)).at_most(2).times

--- a/spec/cb/utils/fluid_attributes_spec.rb
+++ b/spec/cb/utils/fluid_attributes_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 require 'support/mocks/fluid_attributes_extended'
 
@@ -13,7 +23,7 @@ module Cb
 
       it 'returns the attr being set' do
         expect(
-            fluid_obj.some_attr = 'some value'
+          fluid_obj.some_attr = 'some value'
         ).to eq 'some value'
       end
     end
@@ -35,6 +45,5 @@ module Cb
         expect(fluid_obj.another_attr).to eq 'val2'
       end
     end
-
   end
 end

--- a/spec/cb/utils/response_array_extractor_spec.rb
+++ b/spec/cb/utils/response_array_extractor_spec.rb
@@ -1,15 +1,26 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   module Utils
     describe ResponseArrayExtractor do
-
       context 'When a response hash contains a collection that only has one item' do
-        let(:response_hash) {{
-          'Animals' => {
-            'Animal' => 'Moose'
+        let(:response_hash) do
+          {
+            'Animals' => {
+              'Animal' => 'Moose'
+            }
           }
-        }}
+        end
 
         it 'an array with the single item should be returned' do
           animals = Cb::Utils::ResponseArrayExtractor.extract(response_hash, 'Animals')
@@ -20,11 +31,13 @@ module Cb
       end
 
       context 'When a response hash contains a collection that hash multiple items' do
-        let(:response_hash) {{ 
-          'Animals' => { 
-            'Animal' => ['Moose', 'Kitty'] 
-          } 
-        }}
+        let(:response_hash) do
+          {
+            'Animals' => {
+              'Animal' => %w(Moose Kitty)
+            }
+          }
+        end
 
         it 'an array with multiple items should be returned' do
           animals = Cb::Utils::ResponseArrayExtractor.extract(response_hash, 'Animals')
@@ -32,7 +45,7 @@ module Cb
           expect(animals.count).to eq(2)
           expect(animals[0]).to eq('Moose')
           expect(animals[1]).to eq('Kitty')
-        end 
+        end
       end
 
       context 'When an optional singular key is provided' do
@@ -54,9 +67,11 @@ module Cb
       end
 
       context 'When a response hash contains a single item' do
-        let(:response_hash) {{
+        let(:response_hash) do
+          {
             'Hello' => 'world'
-        }}
+          }
+        end
         it 'an array of a single item should be returned' do
           test = Cb::Utils::ResponseArrayExtractor.extract(response_hash, 'Hello')
           expect(test.class).to eq(Array)
@@ -66,9 +81,11 @@ module Cb
       end
 
       context 'When a response hash contains a list of items' do
-        let(:response_hash) {{
+        let(:response_hash) do
+          {
             'Hello' => 'world,this,is,awesome'
-        }}
+          }
+        end
         it 'an array of items should be returned' do
           test = Cb::Utils::ResponseArrayExtractor.extract(response_hash, 'Hello')
           expect(test.class).to eq(Array)
@@ -81,9 +98,9 @@ module Cb
       end
 
       context 'When a response hash contains a single item and not a hash' do
-        let(:response_hash) {
+        let(:response_hash) do
           'hello'
-        }
+        end
         it 'an array of items should be returned' do
           test = Cb::Utils::ResponseArrayExtractor.extract(response_hash, 'Hello')
           expect(test.class).to eq(Array)
@@ -91,7 +108,6 @@ module Cb
           expect(test).to eq([])
         end
       end
-
     end
   end
 end

--- a/spec/cb/utils/response_map_spec.rb
+++ b/spec/cb/utils/response_map_spec.rb
@@ -1,13 +1,22 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe Cb::Utils::ResponseMap do
     context '.response_for' do
-
       let(:response_map) { Cb::Utils::ResponseMap }
 
       it 'should throw an error on a bad entry' do
-        expect { response_map.response_for("Hello") }.to raise_error(Cb::Utils::ResponseNotFoundError)
+        expect { response_map.response_for('Hello') }.to raise_error(Cb::Utils::ResponseNotFoundError)
       end
 
       it 'should test that response_hash_extension is not implemented' do
@@ -28,7 +37,7 @@ module Cb
 
         expect(response_map.response_for(request_namespace::Get)).to eq(response_namespace::Get)
       end
-      
+
       it 'should test company methods' do
         request_namespace = Cb::Requests::Company
         response_namespace = Cb::Responses::Company

--- a/spec/cb/utils/validator_spec.rb
+++ b/spec/cb/utils/validator_spec.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 
 module Cb
   describe ResponseValidator do
-
     let(:response)          { double(HTTParty::Response) }
     let(:response_property) { double('HTTParty::Response.response') }
 
@@ -12,9 +21,9 @@ module Cb
     end
 
     it 'should return empty hash when body is empty' do
-       allow(response.response).to receive(:body).and_return(String.new)
-       validation = ResponseValidator.validate(response)
-       expect(validation.empty?).to be_truthy
+      allow(response.response).to receive(:body).and_return('')
+      validation = ResponseValidator.validate(response)
+      expect(validation.empty?).to be_truthy
     end
 
     it 'should return empty hash when body is improper json/xml' do
@@ -62,7 +71,7 @@ module Cb
 
     it 'should raise an UnauthorizedError when status code is 401' do
       allow(response).to receive(:code).and_return(401)
-      expect{ ResponseValidator.validate(response) }.to raise_error(Cb::UnauthorizedError)
+      expect { ResponseValidator.validate(response) }.to raise_error(Cb::UnauthorizedError)
     end
 
     context 'when there are JSON parsing errors' do
@@ -80,11 +89,9 @@ module Cb
           allow(response.response).to receive(:body).and_return(xml)
           validation = ResponseValidator.validate(response)
           expect(validation).to be_an_instance_of Hash
-          expect(validation).to eq({"yo"=>{"this"=>{"isxml"=>"yay"}}})
+          expect(validation).to eq('yo' => { 'this' => { 'isxml' => 'yay' } })
         end
-
       end
     end
-
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'simplecov'
 SimpleCov.start do
   add_filter '/spec/'

--- a/spec/support/convenience.rb
+++ b/spec/support/convenience.rb
@@ -1,7 +1,16 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 module Cb
   module SpecSupport
     module Convenience
-
       def anything
         /.*/
       end
@@ -9,7 +18,6 @@ module Cb
       def uri_stem(uri_stem_to_match)
         /#{uri_stem_to_match}*/
       end
-
     end
   end
 end

--- a/spec/support/mocks/callback.rb
+++ b/spec/support/mocks/callback.rb
@@ -1,9 +1,20 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 module Mocks
   class Callback
     attr_reader :callback_value
     def initialize
       @callback_value = false
     end
+
     def callback_method(arg)
       @callback_value = arg
     end

--- a/spec/support/mocks/fluid_attributes_extended.rb
+++ b/spec/support/mocks/fluid_attributes_extended.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 module Mocks
   class FluidAttributesExtended
     extend Cb::Utils::FluidAttributes

--- a/spec/support/mocks/oauth_token.rb
+++ b/spec/support/mocks/oauth_token.rb
@@ -1,10 +1,21 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 module Mocks
   class OAuthToken
     attr_reader :what_to_return
     def initialize(what_to_return)
       @what_to_return = what_to_return
     end
-    def get(path, opts = {})
+
+    def get(_path, _opts = {})
       @what_to_return
     end
   end

--- a/spec/support/mocks/observer.rb
+++ b/spec/support/mocks/observer.rb
@@ -1,6 +1,16 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 module Mocks
   class Observer
-    def update(api_call)
+    def update(_api_call)
     end
   end
 end

--- a/spec/support/mocks/request.rb
+++ b/spec/support/mocks/request.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'support/mocks/response'
 
 module Mocks
   class Request
-
     def initialize(arg)
       @arg = arg
     end
@@ -24,7 +33,7 @@ module Mocks
     end
 
     def endpoint_uri
-      "parts unknown"
+      'parts unknown'
     end
 
     def http_method

--- a/spec/support/mocks/response.rb
+++ b/spec/support/mocks/response.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 module Mocks
   class Response
     attr_reader :response

--- a/spec/support/mocks/resume.rb
+++ b/spec/support/mocks/resume.rb
@@ -1,7 +1,16 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 module Mocks
   class Resume
     class << self
-
       def snake_case_resume_hash
         {
           user_identifier: 'userID',
@@ -17,7 +26,7 @@ module Mocks
                 start_date: '2009-09-01T00:00:00',
                 end_date: '2014-08-28T00:00:00',
                 currently_employed_here: true,
-                id:'workexperienceID'
+                id: 'workexperienceID'
               },
               {
                 job_title: 'Hair Stylist',
@@ -26,7 +35,7 @@ module Mocks
                 start_date: '2008-06-01T00:00:00',
                 end_date: '2009-09-01T00:00:00',
                 currently_employed_here: false,
-                id:'workexperienceID'
+                id: 'workexperienceID'
               },
               {
                 job_title: 'Assistant/Receptionist',
@@ -35,7 +44,7 @@ module Mocks
                 start_date: '2006-09-01T00:00:00',
                 end_date: '2008-06-01T00:00:00',
                 currently_employed_here: false,
-                id:'workexperienceID'
+                id: 'workexperienceID'
               },
               {
                 job_title: 'Lead role',
@@ -44,7 +53,7 @@ module Mocks
                 start_date: '2007-03-01T00:00:00',
                 end_date: '2007-05-31T00:00:00',
                 currently_employed_here: false,
-                id:'workexperienceID'
+                id: 'workexperienceID'
               },
               {
                 job_title: 'magic place',
@@ -53,7 +62,7 @@ module Mocks
                 start_date: '2006-03-01T00:00:00',
                 end_date: '2006-05-31T00:00:00',
                 currently_employed_here: false,
-                id:'workexperienceID'
+                id: 'workexperienceID'
               }
             ],
           salary_information:
@@ -83,7 +92,7 @@ module Mocks
           skills_and_qualifications:
             {
               accreditations_and_certifications: '',
-              languages_spoken: [ 'english', 'spanish'],
+              languages_spoken: %w(english spanish),
               has_management_experience: false,
               size_of_team_managed: 0
             },
@@ -110,111 +119,104 @@ module Mocks
 
       def camel_case_resume_hash
         {
-          'userIdentifier'=> 'userID',
-          'resumeHash'=> 'resumeHash',
-          'desiredJobTitle'=> 'TrainHopper',
-          'privacySetting'=> 'Public',
-          'workExperience'=>
-            [
-              {
-                'jobTitle'=> 'Hair Stylist and Colorist',
-                'companyName'=> 'Swan Beauty Parlor',
-                'employmentType'=> 'ETNS',
-                'startDate'=> '2009-09-01T00:00:00',
-                'endDate'=> '2014-08-28T00:00:00',
-                'currentlyEmployedHere'=> true,
-                'id'=>'workexperienceID'
-              },
-              {
-                'jobTitle'=> 'Hair Stylist',
-                'companyName'=> 'Sweet Dreams Beauty Salon',
-                'employmentType'=> 'ETNS',
-                'startDate'=> '2008-06-01T00:00:00',
-                'endDate'=> '2009-09-01T00:00:00',
-                'currentlyEmployedHere'=> false,
-                'id'=>'workexperienceID'
-              },
-              {
-                'jobTitle'=> 'Assistant/Receptionist',
-                'companyName'=> 'Oak Park Beauty',
-                'employmentType'=> 'ETNS',
-                'startDate'=> '2006-09-01T00:00:00',
-                'endDate'=> '2008-06-01T00:00:00',
-                'currentlyEmployedHere'=> false,
-                'id'=>'workexperienceID'
-              },
-              {
-                'jobTitle'=> 'Lead role',
-                'companyName'=> 'The Sound of Music',
-                'employmentType'=> 'ETNS',
-                'startDate'=> '2007-03-01T00:00:00',
-                'endDate'=> '2007-05-31T00:00:00',
-                'currentlyEmployedHere'=> false,
-                'id'=>'workexperienceID'
-              },
-              {
-                'jobTitle'=> 'magic place',
-                'companyName'=> 'Child Cancer Research',
-                'employmentType'=> 'ETNS',
-                'startDate'=> '2006-03-01T00:00:00',
-                'endDate'=> '2006-05-31T00:00:00',
-                'currentlyEmployedHere'=> false,
-                'id'=>'workexperienceID'
-              }
-            ],
-          'salaryInformation'=>
+          'userIdentifier' => 'userID',
+          'resumeHash' => 'resumeHash',
+          'desiredJobTitle' => 'TrainHopper',
+          'privacySetting' => 'Public',
+          'workExperience' =>             [
             {
-              'mostRecentPayAmount'=> 0,
-              'perHourOrPerYear'=> 'Hour',
-              'currencyCode'=> 'USD',
-              'workExperienceId'=>'workexperienceID',
-              'annualBonus'=> 0,
-              'annualCommission'=> 0
-
+              'jobTitle' => 'Hair Stylist and Colorist',
+              'companyName' => 'Swan Beauty Parlor',
+              'employmentType' => 'ETNS',
+              'startDate' => '2009-09-01T00:00:00',
+              'endDate' => '2014-08-28T00:00:00',
+              'currentlyEmployedHere' => true,
+              'id' => 'workexperienceID'
             },
-          'educations'=>
-            [
-              {
-                'schoolName'=> 'Hair dids and magic fluits academy.',
-                'majorOrProgram'=> 'Gettin Hair did',
-                'degree'=> 'CE3',
-                'graduationDate'=> '2008-05-01T00:00:00'
-              },
-              {
-                'schoolName'=> 'Oak Park River Forest High School',
-                'majorOrProgram'=> 'Not Applicable',
-                'degree'=> 'CE31',
-                'graduationDate'=> '2007-05-01T00:00:00'
-              }
-            ],
-          'skillsAndQualifications'=>
             {
-              'accreditationsAndCertifications'=> '',
-              'languagesSpoken'=> ['english', 'spanish'],
-              'hasManagementExperience'=> false,
-              'sizeOfTeamManaged'=> 0
+              'jobTitle' => 'Hair Stylist',
+              'companyName' => 'Sweet Dreams Beauty Salon',
+              'employmentType' => 'ETNS',
+              'startDate' => '2008-06-01T00:00:00',
+              'endDate' => '2009-09-01T00:00:00',
+              'currentlyEmployedHere' => false,
+              'id' => 'workexperienceID'
             },
-          'relocations'=>
-            [
-              {
-                'city'=> 'atlanta',
-                'adminArea'=> '',
-                'countryCode'=> 'us'
-              },
-              {
-                'city'=> 'winter',
-                'adminArea'=> '',
-                'countryCode'=> 'us'
-              }
-            ],
-          'governmentAndMilitary'=>
             {
-              'hasSecurityClearance'=> false,
-              'militaryExperience'=> ''
+              'jobTitle' => 'Assistant/Receptionist',
+              'companyName' => 'Oak Park Beauty',
+              'employmentType' => 'ETNS',
+              'startDate' => '2006-09-01T00:00:00',
+              'endDate' => '2008-06-01T00:00:00',
+              'currentlyEmployedHere' => false,
+              'id' => 'workexperienceID'
+            },
+            {
+              'jobTitle' => 'Lead role',
+              'companyName' => 'The Sound of Music',
+              'employmentType' => 'ETNS',
+              'startDate' => '2007-03-01T00:00:00',
+              'endDate' => '2007-05-31T00:00:00',
+              'currentlyEmployedHere' => false,
+              'id' => 'workexperienceID'
+            },
+            {
+              'jobTitle' => 'magic place',
+              'companyName' => 'Child Cancer Research',
+              'employmentType' => 'ETNS',
+              'startDate' => '2006-03-01T00:00:00',
+              'endDate' => '2006-05-31T00:00:00',
+              'currentlyEmployedHere' => false,
+              'id' => 'workexperienceID'
             }
+          ],
+          'salaryInformation' =>             {
+            'mostRecentPayAmount' => 0,
+            'perHourOrPerYear' => 'Hour',
+            'currencyCode' => 'USD',
+            'workExperienceId' => 'workexperienceID',
+            'annualBonus' => 0,
+            'annualCommission' => 0
+
+          },
+          'educations' =>             [
+            {
+              'schoolName' => 'Hair dids and magic fluits academy.',
+              'majorOrProgram' => 'Gettin Hair did',
+              'degree' => 'CE3',
+              'graduationDate' => '2008-05-01T00:00:00'
+            },
+            {
+              'schoolName' => 'Oak Park River Forest High School',
+              'majorOrProgram' => 'Not Applicable',
+              'degree' => 'CE31',
+              'graduationDate' => '2007-05-01T00:00:00'
+            }
+          ],
+          'skillsAndQualifications' =>             {
+            'accreditationsAndCertifications' => '',
+            'languagesSpoken' => %w(english spanish),
+            'hasManagementExperience' => false,
+            'sizeOfTeamManaged' => 0
+          },
+          'relocations' =>             [
+            {
+              'city' => 'atlanta',
+              'adminArea' => '',
+              'countryCode' => 'us'
+            },
+            {
+              'city' => 'winter',
+              'adminArea' => '',
+              'countryCode' => 'us'
+            }
+          ],
+          'governmentAndMilitary' =>             {
+            'hasSecurityClearance' => false,
+            'militaryExperience' => ''
+          }
         }
       end
-
     end
   end
 end

--- a/spec/support/mocks/saved_search.rb
+++ b/spec/support/mocks/saved_search.rb
@@ -1,8 +1,17 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'json'
 
 module Mocks
   class SavedSearch
-
     class << self
       def list
         JSON.parse '{
@@ -134,7 +143,6 @@ module Mocks
           "WasSuccessful":true
         }'
       end
-      
     end
   end
 end

--- a/specsmoke/get_spec.rb
+++ b/specsmoke/get_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 require 'webmock'
 require 'dotenv'
@@ -9,7 +19,7 @@ Cb.configuration.dev_key = ENV['DEVELOPER_KEY']
 Cb.configuration.debug_api = false
 
 module Cb::Clients
-  describe "GET requests" do
+  describe 'GET requests' do
     describe Job do
       describe '#find_by_did' do
         context 'with a real job_did' do
@@ -17,7 +27,7 @@ module Cb::Clients
             job_did = 'JHQ4LP5YY6S4HLFTVM0'
             @response = Cb::Clients::Job.find_by_did(job_did)
           end
-          
+
           it 'returns a valid response' do
             @response.should be_a Cb::Responses::Job::Singular
           end
@@ -39,6 +49,5 @@ module Cb::Clients
         end
       end
     end
-
   end
 end

--- a/specsmoke/post_spec.rb
+++ b/specsmoke/post_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 require 'webmock'
 require 'dotenv'
@@ -9,32 +19,32 @@ Cb.configuration.dev_key = ENV['DEVELOPER_KEY']
 Cb.configuration.debug_api = false
 
 module Cb::Clients
-  describe "POST requests" do
+  describe 'POST requests' do
     describe Application do
       describe '::create' do
         before(:all) do
           job_did = 'JHQ4LP5YY6S4HLFTVM0'
           resume = Cb::Criteria::Application::Resume.new
-            .external_resume_id('XRHN1QJ6V0DZPZHBPZNM')
-            .resume_file_name('my resume')
-            .resume_data(1010101010101)
-            .resume_extension('pdf')
-            .resume_title('Nurse')
+                   .external_resume_id('XRHN1QJ6V0DZPZHBPZNM')
+                   .resume_file_name('my resume')
+                   .resume_data(1_010_101_010_101)
+                   .resume_extension('pdf')
+                   .resume_title('Nurse')
           cover_letter = Cb::Criteria::Application::CoverLetter.new
           resume_responses = []
           criteria = Cb::Criteria::Application::Create.new
-            .job_did(job_did)
-            .is_submitted(false)
-            .external_user_id('XRHL5WB644K882Z72Y7B')
-            .vid('hamburger_avalanche')
-            .bid('bid_123')
-            .sid('sid_123')
-            .site_id('site_123')
-            .ipath_id('ipath_123')
-            .tn_did('tn_123')
-            .resume(resume)
-            .cover_letter(cover_letter)
-            .responses(resume_responses)
+                     .job_did(job_did)
+                     .is_submitted(false)
+                     .external_user_id('XRHL5WB644K882Z72Y7B')
+                     .vid('hamburger_avalanche')
+                     .bid('bid_123')
+                     .sid('sid_123')
+                     .site_id('site_123')
+                     .ipath_id('ipath_123')
+                     .tn_did('tn_123')
+                     .resume(resume)
+                     .cover_letter(cover_letter)
+                     .responses(resume_responses)
           @response = Cb::Clients::Application.create(criteria)
         end
 

--- a/specsmoke/put_spec.rb
+++ b/specsmoke/put_spec.rb
@@ -1,3 +1,13 @@
+# Copyright 2015 CareerBuilder, LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 require 'spec_helper'
 require 'webmock'
 require 'dotenv'
@@ -9,33 +19,33 @@ Cb.configuration.dev_key = ENV['DEVELOPER_KEY']
 Cb.configuration.debug_api = false
 
 module Cb::Clients
-  describe "PUT requests" do
+  describe 'PUT requests' do
     describe Application do
       describe '::update' do
         before(:all) do
           job_did = 'JHQ4LP5YY6S4HLFTVM0'
           resume = Cb::Criteria::Application::Resume.new
-            .external_resume_id('XRHN1QJ6V0DZPZHBPZNM')
-            .resume_file_name('my resume')
-            .resume_data(1010101010101)
-            .resume_extension('pdf')
-            .resume_title('Nurse')
+                   .external_resume_id('XRHN1QJ6V0DZPZHBPZNM')
+                   .resume_file_name('my resume')
+                   .resume_data(1_010_101_010_101)
+                   .resume_extension('pdf')
+                   .resume_title('Nurse')
           cover_letter = Cb::Criteria::Application::CoverLetter.new
           resume_responses = []
           criteria = Cb::Criteria::Application::Update.new
-            .application_did('JAHH0636ZLWMF8DRW30T')
-            .job_did(job_did)
-            .is_submitted(false)
-            .external_user_id('XRHL5WB644K882Z72Y7B')
-            .vid('hamburger_avalanche')
-            .bid('bid_123')
-            .sid('sid_123')
-            .site_id('site_123')
-            .ipath_id('ipath_123')
-            .tn_did('tn_123')
-            .resume(resume)
-            .cover_letter(cover_letter)
-            .responses(resume_responses)
+                     .application_did('JAHH0636ZLWMF8DRW30T')
+                     .job_did(job_did)
+                     .is_submitted(false)
+                     .external_user_id('XRHL5WB644K882Z72Y7B')
+                     .vid('hamburger_avalanche')
+                     .bid('bid_123')
+                     .sid('sid_123')
+                     .site_id('site_123')
+                     .ipath_id('ipath_123')
+                     .tn_did('tn_123')
+                     .resume(resume)
+                     .cover_letter(cover_letter)
+                     .responses(resume_responses)
           @response = Cb::Clients::Application.update(criteria)
         end
 


### PR DESCRIPTION
This adds the copyright notice to our specs and also runs rubocop across them to correct whitespace and tabbing type issues.