### PR TITLE
Transfer ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Code Climate](https://codeclimate.com/repos/54242d7ce30ba04b220066b1/badges/32deaad52cf116f360f3/gpa.svg)](https://codeclimate.com/repos/54242d7ce30ba04b220066b1/feed)[![Test Coverage](https://codeclimate.com/repos/54242d7ce30ba04b220066b1/badges/32deaad52cf116f360f3/coverage.svg)](https://codeclimate.com/repos/54242d7ce30ba04b220066b1/coverage)
+
 First things first. You're going to need to get a developer key from Careerbuilder. Developer keys are available to Partners. You can fill out the form at http://developer.careerbuilder.com/partner_messages/new to become a Partner.
 
 Now that you have a key, lets get to the good stuff.

--- a/cb-api.gemspec
+++ b/cb-api.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-pride', '~> 3.0'
   s.add_development_dependency 'pry', '0.9.12.1'
   s.add_development_dependency 'rb-readline', '~> 0.5.0'
+  s.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ require 'cb'
 require 'webmock/rspec'
 require 'pry'
 
-WebMock.disable_net_connect!
+WebMock.disable_net_connect!(allow: 'codeclimate.com')
 
 RSpec.configure do |c|
   c.mock_with :rspec do |mocks|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,9 @@
 require 'simplecov'
+require 'codeclimate-test-reporter'
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+    SimpleCov::Formatter::HTMLFormatter,
+    CodeClimate::TestReporter::Formatter
+]
 SimpleCov.start do
   add_filter '/spec/'
   add_group 'utils', 'lib/cb/utils'


### PR DESCRIPTION
Adds the code climate badges and the code climate reporter so we can actually send them our code coverage numbers.  Build is already setup to do so but we didn't include this gem.